### PR TITLE
fix: container resource naming in docs

### DIFF
--- a/docs/resources/container.md
+++ b/docs/resources/container.md
@@ -13,7 +13,7 @@ Use this data source to retrieve information about an existing container.
 ## Example Usage
 
 ```terraform
-resource "qovery_container_registry" "my_container_registry" {
+resource "qovery_container" "my_container" {
   # Required
   environment_id = qovery_environment.my_environment.id
   registry_id    = qovery_container_registry.my_container_registry.id

--- a/examples/resources/qovery_container/resource.tf
+++ b/examples/resources/qovery_container/resource.tf
@@ -1,4 +1,4 @@
-resource "qovery_container_registry" "my_container_registry" {
+resource "qovery_container" "my_container" {
   # Required
   environment_id = qovery_environment.my_environment.id
   registry_id    = qovery_container_registry.my_container_registry.id


### PR DESCRIPTION
This PR aims to fix container resource bad naming in documentation. `qovery_container` was wrongly set as `qovery_container_registry`.