### PR TITLE
fix: use list instead of set for container and application arguments

### DIFF
--- a/docs/data-sources/application.md
+++ b/docs/data-sources/application.md
@@ -31,7 +31,7 @@ data "qovery_application" "my_application" {
 
 ### Read-Only
 
-- `arguments` (Set of String) List of arguments of this container.
+- `arguments` (List of String) List of arguments of this container.
 - `auto_preview` (Boolean) Specify if the environment preview option is activated or not for this application.
 - `build_mode` (String) Build Mode of the application.
 - `buildpack_language` (String) Buildpack Language framework.

--- a/docs/data-sources/container.md
+++ b/docs/data-sources/container.md
@@ -31,7 +31,7 @@ data "qovery_container" "my_container" {
 
 ### Read-Only
 
-- `arguments` (Set of String) List of arguments of this container.
+- `arguments` (List of String) List of arguments of this container.
 - `auto_preview` (Boolean) Specify if the environment preview option is activated or not for this container.
 - `built_in_environment_variables` (Attributes Set) List of built-in environment variables linked to this container. (see [below for nested schema](#nestedatt--built_in_environment_variables))
 - `cpu` (Number) CPU of the container in millicores (m) [1000m = 1 CPU].

--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -69,7 +69,7 @@ resource "qovery_application" "my_application" {
 
 ### Optional
 
-- `arguments` (Set of String) List of arguments of this application.
+- `arguments` (List of String) List of arguments of this application.
 - `auto_preview` (Boolean) Specify if the environment preview option is activated or not for this application.
 	- Default: `false`.
 - `build_mode` (String) Build Mode of the application.

--- a/docs/resources/container.md
+++ b/docs/resources/container.md
@@ -62,7 +62,7 @@ resource "qovery_container" "my_container" {
 
 ### Optional
 
-- `arguments` (Set of String) List of arguments of this container.
+- `arguments` (List of String) List of arguments of this container.
 - `auto_preview` (Boolean) Specify if the environment preview option is activated or not for this container.
 - `cpu` (Number) CPU of the container in millicores (m) [1000m = 1 CPU].
 	- Must be: `>= 250`.

--- a/qovery/data_source_application.go
+++ b/qovery/data_source_application.go
@@ -134,7 +134,7 @@ func (d applicationDataSource) GetSchema(_ context.Context) (tfsdk.Schema, diag.
 			"arguments": {
 				Description: "List of arguments of this container.",
 				Computed:    true,
-				Type: types.SetType{
+				Type: types.ListType{
 					ElemType: types.StringType,
 				},
 			},

--- a/qovery/data_source_container.go
+++ b/qovery/data_source_container.go
@@ -240,7 +240,7 @@ func (d containerDataSource) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 			"arguments": {
 				Description: "List of arguments of this container.",
 				Computed:    true,
-				Type: types.SetType{
+				Type: types.ListType{
 					ElemType: types.StringType,
 				},
 			},

--- a/qovery/modifiers/string_slice_default_modifier.go
+++ b/qovery/modifiers/string_slice_default_modifier.go
@@ -39,7 +39,7 @@ func (m StringSliceDefaultModifier) MarkdownDescription(_ context.Context) strin
 // `resp` contains fields for updating the planned value, triggering resource
 // replacement, and returning diagnostics.
 func (m StringSliceDefaultModifier) Modify(ctx context.Context, req tfsdk.ModifyAttributePlanRequest, resp *tfsdk.ModifyAttributePlanResponse) {
-	var attribute types.Set
+	var attribute types.List
 	resp.Diagnostics.Append(tfsdk.ValueAs(ctx, req.AttributePlan, &attribute)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -49,7 +49,7 @@ func (m StringSliceDefaultModifier) Modify(ctx context.Context, req tfsdk.Modify
 		return
 	}
 
-	set := types.Set{
+	set := types.List{
 		ElemType: types.StringType,
 	}
 

--- a/qovery/resource_application.go
+++ b/qovery/resource_application.go
@@ -273,7 +273,7 @@ func (r applicationResource) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 				Description: "List of arguments of this application.",
 				Optional:    true,
 				Computed:    true,
-				Type: types.SetType{
+				Type: types.ListType{
 					ElemType: types.StringType,
 				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{

--- a/qovery/resource_application_model.go
+++ b/qovery/resource_application_model.go
@@ -30,7 +30,7 @@ type Application struct {
 	InternalHost                types.String              `tfsdk:"internal_host"`
 	State                       types.String              `tfsdk:"state"`
 	Entrypoint                  types.String              `tfsdk:"entrypoint"`
-	Arguments                   types.Set                 `tfsdk:"arguments"`
+	Arguments                   types.List                `tfsdk:"arguments"`
 }
 
 func (app Application) EnvironmentVariableList() EnvironmentVariableList {

--- a/qovery/resource_container.go
+++ b/qovery/resource_container.go
@@ -333,7 +333,7 @@ func (r containerResource) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diag
 				Description: "List of arguments of this container.",
 				Optional:    true,
 				Computed:    true,
-				Type: types.SetType{
+				Type: types.ListType{
 					ElemType: types.StringType,
 				},
 				PlanModifiers: tfsdk.AttributePlanModifiers{

--- a/qovery/resource_container_model.go
+++ b/qovery/resource_container_model.go
@@ -29,7 +29,7 @@ type Container struct {
 	Storages                    types.Set    `tfsdk:"storage"`
 	Ports                       types.Set    `tfsdk:"ports"`
 	//CustomDomains               types.Set    `tfsdk:"custom_domains"`
-	Arguments    types.Set    `tfsdk:"arguments"`
+	Arguments    types.List   `tfsdk:"arguments"`
 	ExternalHost types.String `tfsdk:"external_host"`
 	InternalHost types.String `tfsdk:"internal_host"`
 	State        types.String `tfsdk:"state"`

--- a/qovery/types_conversions.go
+++ b/qovery/types_conversions.go
@@ -144,7 +144,7 @@ func toMapStringString(v types.Map) map[string]string {
 	return ret
 }
 
-func toStringArray(set types.Set) []string {
+func toStringArray(set types.List) []string {
 	if set.Null || set.Unknown {
 		return []string{}
 	}
@@ -212,8 +212,8 @@ func fromBoolPointer(v *bool) types.Bool {
 	return fromBool(*v)
 }
 
-func fromStringArray(array []string) types.Set {
-	set := types.Set{
+func fromStringArray(array []string) types.List {
+	set := types.List{
 		ElemType: types.StringType,
 	}
 


### PR DESCRIPTION
# Problem
When using application or container `arguments` list, Qovery dashboard show arguments in the wrong order.

# Cause
The Qovery terraform provider use `SetType`. This type is an unordered collection.

# Solution
We use `List` instead of `Set`