### PR TITLE
tests: jobs ease acceptance test craft

### DIFF
--- a/qovery/cluster_route_model.go
+++ b/qovery/cluster_route_model.go
@@ -65,17 +65,17 @@ func (r ClusterRoute) toTerraformObject() types.Object {
 
 func (r ClusterRoute) toUpsertRequest() client.ClusterRoute {
 	return client.ClusterRoute{
-		Description: toString(r.Description),
-		Destination: toString(r.Destination),
-		Target:      toString(r.Target),
+		Description: ToString(r.Description),
+		Destination: ToString(r.Destination),
+		Target:      ToString(r.Target),
 	}
 }
 
 func fromClusterRoute(r client.ClusterRoute) ClusterRoute {
 	return ClusterRoute{
-		Description: fromString(r.Description),
-		Destination: fromString(r.Destination),
-		Target:      fromString(r.Target),
+		Description: FromString(r.Description),
+		Destination: FromString(r.Destination),
+		Target:      FromString(r.Target),
 	}
 }
 

--- a/qovery/custom_domain_model.go
+++ b/qovery/custom_domain_model.go
@@ -62,7 +62,7 @@ func (domains CustomDomainList) diff(oldDomains CustomDomainList) client.CustomD
 	}
 
 	for _, od := range oldDomains {
-		if found := domains.find(toString(od.Domain)); found == nil {
+		if found := domains.find(ToString(od.Domain)); found == nil {
 			diff.Delete = append(diff.Delete, od.toDeleteRequest())
 		}
 	}
@@ -98,31 +98,31 @@ func (d CustomDomain) toTerraformObject() types.Object {
 func (d CustomDomain) toCreateRequest() client.CustomDomainCreateRequest {
 	return client.CustomDomainCreateRequest{
 		CustomDomainRequest: qovery.CustomDomainRequest{
-			Domain: toString(d.Domain),
+			Domain: ToString(d.Domain),
 		},
 	}
 }
 
 func (d CustomDomain) toUpdateRequest(new CustomDomain) client.CustomDomainUpdateRequest {
 	return client.CustomDomainUpdateRequest{
-		Id: toString(d.Id),
+		Id: ToString(d.Id),
 		CustomDomainRequest: qovery.CustomDomainRequest{
-			Domain: toString(new.Domain),
+			Domain: ToString(new.Domain),
 		},
 	}
 }
 
 func (d CustomDomain) toDeleteRequest() client.CustomDomainDeleteRequest {
 	return client.CustomDomainDeleteRequest{
-		Id: toString(d.Id),
+		Id: ToString(d.Id),
 	}
 }
 
 func fromCustomDomain(d *qovery.CustomDomain) CustomDomain {
 	return CustomDomain{
-		Id:               fromString(d.Id),
-		Domain:           fromString(d.Domain),
-		ValidationDomain: fromStringPointer(d.ValidationDomain),
+		Id:               FromString(d.Id),
+		Domain:           FromString(d.Domain),
+		ValidationDomain: FromStringPointer(d.ValidationDomain),
 		Status:           fromClientEnumPointer(d.Status),
 	}
 }

--- a/qovery/data_source_deployment.go
+++ b/qovery/data_source_deployment.go
@@ -86,10 +86,10 @@ func (d deploymentDataSource) Read(ctx context.Context, req datasource.ReadReque
 
 	// Get deployment from API
 	_, err := d.deploymentService.Get(ctx, newdeployment.NewDeploymentParams{
-		ID:            toStringPointer(data.Id),
-		EnvironmentID: toString(data.EnvironmentId),
-		Version:       toStringPointer(data.Version),
-		DesiredState:  toString(data.DesiredState),
+		ID:            ToStringPointer(data.Id),
+		EnvironmentID: ToString(data.EnvironmentId),
+		Version:       ToStringPointer(data.Version),
+		DesiredState:  ToString(data.DesiredState),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Error on deployment read", err.Error())

--- a/qovery/environment_variable_model.go
+++ b/qovery/environment_variable_model.go
@@ -62,7 +62,7 @@ func (vars EnvironmentVariableList) diffRequest(old EnvironmentVariableList) var
 	}
 
 	for _, e := range old {
-		if updatedVar := vars.find(toString(e.Key)); updatedVar != nil {
+		if updatedVar := vars.find(ToString(e.Key)); updatedVar != nil {
 			if updatedVar.Value != e.Value {
 				diff.Update = append(diff.Update, e.toDiffUpdateRequest(*updatedVar))
 			}
@@ -88,7 +88,7 @@ func (vars EnvironmentVariableList) diff(old EnvironmentVariableList) client.Env
 	}
 
 	for _, e := range old {
-		if updatedVar := vars.find(toString(e.Key)); updatedVar != nil {
+		if updatedVar := vars.find(ToString(e.Key)); updatedVar != nil {
 			if updatedVar.Value != e.Value {
 				diff.Update = append(diff.Update, e.toUpdateRequest(*updatedVar))
 			}
@@ -126,8 +126,8 @@ func (e EnvironmentVariable) toTerraformObject() types.Object {
 func (e EnvironmentVariable) toCreateRequest() client.EnvironmentVariableCreateRequest {
 	return client.EnvironmentVariableCreateRequest{
 		EnvironmentVariableRequest: qovery.EnvironmentVariableRequest{
-			Key:   toString(e.Key),
-			Value: toString(e.Value),
+			Key:   ToString(e.Key),
+			Value: ToString(e.Value),
 		},
 	}
 }
@@ -135,49 +135,49 @@ func (e EnvironmentVariable) toCreateRequest() client.EnvironmentVariableCreateR
 func (e EnvironmentVariable) toDiffCreateRequest() variable.DiffCreateRequest {
 	return variable.DiffCreateRequest{
 		UpsertRequest: variable.UpsertRequest{
-			Key:   toString(e.Key),
-			Value: toString(e.Value),
+			Key:   ToString(e.Key),
+			Value: ToString(e.Value),
 		},
 	}
 }
 
 func (e EnvironmentVariable) toUpdateRequest(new EnvironmentVariable) client.EnvironmentVariableUpdateRequest {
 	return client.EnvironmentVariableUpdateRequest{
-		Id: toString(e.Id),
+		Id: ToString(e.Id),
 		EnvironmentVariableEditRequest: qovery.EnvironmentVariableEditRequest{
-			Key:   toString(e.Key),
-			Value: toString(new.Value),
+			Key:   ToString(e.Key),
+			Value: ToString(new.Value),
 		},
 	}
 }
 
 func (e EnvironmentVariable) toDiffUpdateRequest(new EnvironmentVariable) variable.DiffUpdateRequest {
 	return variable.DiffUpdateRequest{
-		VariableID: toString(e.Id),
+		VariableID: ToString(e.Id),
 		UpsertRequest: variable.UpsertRequest{
-			Key:   toString(e.Key),
-			Value: toString(new.Value),
+			Key:   ToString(e.Key),
+			Value: ToString(new.Value),
 		},
 	}
 }
 
 func (e EnvironmentVariable) toDeleteRequest() client.EnvironmentVariableDeleteRequest {
 	return client.EnvironmentVariableDeleteRequest{
-		Id: toString(e.Id),
+		Id: ToString(e.Id),
 	}
 }
 
 func (e EnvironmentVariable) toDiffDeleteRequest() variable.DiffDeleteRequest {
 	return variable.DiffDeleteRequest{
-		VariableID: toString(e.Id),
+		VariableID: ToString(e.Id),
 	}
 }
 
 func fromEnvironmentVariable(v *qovery.EnvironmentVariable) EnvironmentVariable {
 	return EnvironmentVariable{
-		Id:    fromString(v.Id),
-		Key:   fromString(v.Key),
-		Value: fromString(v.Value),
+		Id:    FromString(v.Id),
+		Key:   FromString(v.Key),
+		Value: FromString(v.Value),
 	}
 }
 
@@ -234,8 +234,8 @@ func convertDomainVariablesToEnvironmentVariableList(vars variable.Variables, sc
 
 func convertDomainVariableToEnvironmentVariable(v variable.Variable) EnvironmentVariable {
 	return EnvironmentVariable{
-		Id:    fromString(v.ID.String()),
-		Key:   fromString(v.Key),
-		Value: fromString(v.Value),
+		Id:    FromString(v.ID.String()),
+		Key:   FromString(v.Key),
+		Value: FromString(v.Value),
 	}
 }

--- a/qovery/port_model.go
+++ b/qovery/port_model.go
@@ -62,22 +62,22 @@ func (p Port) toTerraformObject() types.Object {
 
 func (p Port) toUpsertRequest() port.UpsertRequest {
 	return port.UpsertRequest{
-		Name:               toStringPointer(p.Name),
-		Protocol:           toStringPointer(p.Protocol),
-		InternalPort:       toInt32(p.InternalPort),
-		ExternalPort:       toInt32Pointer(p.ExternalPort),
-		PubliclyAccessible: toBool(p.PubliclyAccessible),
+		Name:               ToStringPointer(p.Name),
+		Protocol:           ToStringPointer(p.Protocol),
+		InternalPort:       ToInt32(p.InternalPort),
+		ExternalPort:       ToInt32Pointer(p.ExternalPort),
+		PubliclyAccessible: ToBool(p.PubliclyAccessible),
 	}
 }
 
 func fromPort(p port.Port) Port {
 	return Port{
-		Id:                 fromString(p.ID.String()),
-		Name:               fromStringPointer(p.Name),
-		Protocol:           fromString(p.Protocol.String()),
-		InternalPort:       fromInt32(p.InternalPort),
-		ExternalPort:       fromInt32Pointer(p.ExternalPort),
-		PubliclyAccessible: fromBool(p.PubliclyAccessible),
+		Id:                 FromString(p.ID.String()),
+		Name:               FromStringPointer(p.Name),
+		Protocol:           FromString(p.Protocol.String()),
+		InternalPort:       FromInt32(p.InternalPort),
+		ExternalPort:       FromInt32Pointer(p.ExternalPort),
+		PubliclyAccessible: FromBool(p.PubliclyAccessible),
 	}
 }
 
@@ -107,12 +107,12 @@ func convertDomainPortsToPortList(ports port.Ports) PortList {
 
 func convertDomainPortToPort(s port.Port) Port {
 	return Port{
-		Id:                 fromString(s.ID.String()),
-		Name:               fromStringPointer(s.Name),
-		Protocol:           fromString(s.Protocol.String()),
-		InternalPort:       fromInt32(s.InternalPort),
-		ExternalPort:       fromInt32Pointer(s.ExternalPort),
-		PubliclyAccessible: fromBool(s.PubliclyAccessible),
+		Id:                 FromString(s.ID.String()),
+		Name:               FromStringPointer(s.Name),
+		Protocol:           FromString(s.Protocol.String()),
+		InternalPort:       FromInt32(s.InternalPort),
+		ExternalPort:       FromInt32Pointer(s.ExternalPort),
+		PubliclyAccessible: FromBool(s.PubliclyAccessible),
 	}
 }
 

--- a/qovery/resource_application.go
+++ b/qovery/resource_application.go
@@ -498,7 +498,7 @@ func (r applicationResource) Create(ctx context.Context, req resource.CreateRequ
 		resp.Diagnostics.AddError(err.Error(), err.Error())
 		return
 	}
-	application, apiErr := r.client.CreateApplication(ctx, toString(plan.EnvironmentId), request)
+	application, apiErr := r.client.CreateApplication(ctx, ToString(plan.EnvironmentId), request)
 	if apiErr != nil {
 		resp.Diagnostics.AddError(apiErr.Summary(), apiErr.Detail())
 		return

--- a/qovery/resource_application_model.go
+++ b/qovery/resource_application_model.go
@@ -70,7 +70,7 @@ func (app Application) toCreateApplicationRequest() (*client.ApplicationCreatePa
 
 	var buildMode *qovery.BuildModeEnum
 	if !app.BuildMode.Null && !app.BuildMode.Unknown {
-		bm, err := qovery.NewBuildModeEnumFromValue(toString(app.BuildMode))
+		bm, err := qovery.NewBuildModeEnumFromValue(ToString(app.BuildMode))
 		if err != nil {
 			return nil, err
 		}
@@ -79,25 +79,25 @@ func (app Application) toCreateApplicationRequest() (*client.ApplicationCreatePa
 
 	return &client.ApplicationCreateParams{
 		ApplicationRequest: qovery.ApplicationRequest{
-			Name:                toString(app.Name),
+			Name:                ToString(app.Name),
 			BuildMode:           buildMode,
-			DockerfilePath:      toNullableString(app.DockerfilePath),
-			BuildpackLanguage:   toNullableNullableBuildPackLanguageEnum(app.BuildpackLanguage),
-			Cpu:                 toInt32Pointer(app.CPU),
-			Memory:              toInt32Pointer(app.Memory),
-			MinRunningInstances: toInt32Pointer(app.MinRunningInstances),
-			MaxRunningInstances: toInt32Pointer(app.MaxRunningInstances),
-			AutoPreview:         toBoolPointer(app.AutoPreview),
+			DockerfilePath:      ToNullableString(app.DockerfilePath),
+			BuildpackLanguage:   ToNullableNullableBuildPackLanguageEnum(app.BuildpackLanguage),
+			Cpu:                 ToInt32Pointer(app.CPU),
+			Memory:              ToInt32Pointer(app.Memory),
+			MinRunningInstances: ToInt32Pointer(app.MinRunningInstances),
+			MaxRunningInstances: ToInt32Pointer(app.MaxRunningInstances),
+			AutoPreview:         ToBoolPointer(app.AutoPreview),
 			GitRepository:       app.GitRepository.toCreateRequest(),
 			Storage:             storage,
 			Ports:               ports,
-			Entrypoint:          toStringPointer(app.Entrypoint),
-			Arguments:           toStringArray(app.Arguments),
+			Entrypoint:          ToStringPointer(app.Entrypoint),
+			Arguments:           ToStringArray(app.Arguments),
 		},
 		EnvironmentVariablesDiff:     app.EnvironmentVariableList().diff(nil),
 		SecretsDiff:                  app.SecretList().diff(nil),
 		CustomDomainsDiff:            app.CustomDomainsList().diff(nil),
-		ApplicationDeploymentStageID: toString(app.DeploymentStageId),
+		ApplicationDeploymentStageID: ToString(app.DeploymentStageId),
 	}, nil
 
 }
@@ -118,7 +118,7 @@ func (app Application) toUpdateApplicationRequest(state Application) (*client.Ap
 		var storageId string
 		value, exists := stateApplicationStoragesByMountPoint[storage.MountPoint.String()]
 		if exists {
-			storageId = toString(value.Id)
+			storageId = ToString(value.Id)
 		}
 
 		s, err := storage.toUpdateRequest(storageId)
@@ -139,7 +139,7 @@ func (app Application) toUpdateApplicationRequest(state Application) (*client.Ap
 
 	var buildMode *qovery.BuildModeEnum
 	if !app.BuildMode.Null && !app.BuildMode.Unknown {
-		bm, err := qovery.NewBuildModeEnumFromValue(toString(app.BuildMode))
+		bm, err := qovery.NewBuildModeEnumFromValue(ToString(app.BuildMode))
 		if err != nil {
 			return nil, err
 		}
@@ -147,44 +147,44 @@ func (app Application) toUpdateApplicationRequest(state Application) (*client.Ap
 	}
 
 	applicationEditRequest := qovery.ApplicationEditRequest{
-		Name:                toStringPointer(app.Name),
+		Name:                ToStringPointer(app.Name),
 		BuildMode:           buildMode,
-		DockerfilePath:      toStringPointer(app.DockerfilePath),
-		BuildpackLanguage:   toNullableNullableBuildPackLanguageEnum(app.BuildpackLanguage),
-		Cpu:                 toInt32Pointer(app.CPU),
-		Memory:              toInt32Pointer(app.Memory),
-		MinRunningInstances: toInt32Pointer(app.MinRunningInstances),
-		MaxRunningInstances: toInt32Pointer(app.MaxRunningInstances),
-		AutoPreview:         toBoolPointer(app.AutoPreview),
+		DockerfilePath:      ToStringPointer(app.DockerfilePath),
+		BuildpackLanguage:   ToNullableNullableBuildPackLanguageEnum(app.BuildpackLanguage),
+		Cpu:                 ToInt32Pointer(app.CPU),
+		Memory:              ToInt32Pointer(app.Memory),
+		MinRunningInstances: ToInt32Pointer(app.MinRunningInstances),
+		MaxRunningInstances: ToInt32Pointer(app.MaxRunningInstances),
+		AutoPreview:         ToBoolPointer(app.AutoPreview),
 		GitRepository:       app.GitRepository.toUpdateRequest(),
 		Storage:             applicationStorageRequest,
 		Ports:               ports,
-		Entrypoint:          toStringPointer(app.Entrypoint),
-		Arguments:           toStringArray(app.Arguments),
+		Entrypoint:          ToStringPointer(app.Entrypoint),
+		Arguments:           ToStringArray(app.Arguments),
 	}
 	return &client.ApplicationUpdateParams{
 		ApplicationEditRequest:       applicationEditRequest,
 		EnvironmentVariablesDiff:     app.EnvironmentVariableList().diff(state.EnvironmentVariableList()),
 		SecretsDiff:                  app.SecretList().diff(state.SecretList()),
 		CustomDomainsDiff:            app.CustomDomainsList().diff(state.CustomDomainsList()),
-		ApplicationDeploymentStageID: toString(app.DeploymentStageId),
+		ApplicationDeploymentStageID: ToString(app.DeploymentStageId),
 	}, nil
 
 }
 
 func convertResponseToApplication(state Application, app *client.ApplicationResponse) Application {
 	return Application{
-		Id:                          fromString(app.ApplicationResponse.Id),
-		EnvironmentId:               fromString(app.ApplicationResponse.Environment.Id),
-		Name:                        fromStringPointer(app.ApplicationResponse.Name),
+		Id:                          FromString(app.ApplicationResponse.Id),
+		EnvironmentId:               FromString(app.ApplicationResponse.Environment.Id),
+		Name:                        FromStringPointer(app.ApplicationResponse.Name),
 		BuildMode:                   fromClientEnumPointer(app.ApplicationResponse.BuildMode),
-		DockerfilePath:              fromNullableString(app.ApplicationResponse.DockerfilePath),
-		BuildpackLanguage:           fromNullableNullableBuildPackLanguageEnum(app.ApplicationResponse.BuildpackLanguage),
-		CPU:                         fromInt32Pointer(app.ApplicationResponse.Cpu),
-		Memory:                      fromInt32Pointer(app.ApplicationResponse.Memory),
-		MinRunningInstances:         fromInt32Pointer(app.ApplicationResponse.MinRunningInstances),
-		MaxRunningInstances:         fromInt32Pointer(app.ApplicationResponse.MaxRunningInstances),
-		AutoPreview:                 fromBoolPointer(app.ApplicationResponse.AutoPreview),
+		DockerfilePath:              FromNullableString(app.ApplicationResponse.DockerfilePath),
+		BuildpackLanguage:           FromNullableNullableBuildPackLanguageEnum(app.ApplicationResponse.BuildpackLanguage),
+		CPU:                         FromInt32Pointer(app.ApplicationResponse.Cpu),
+		Memory:                      FromInt32Pointer(app.ApplicationResponse.Memory),
+		MinRunningInstances:         FromInt32Pointer(app.ApplicationResponse.MinRunningInstances),
+		MaxRunningInstances:         FromInt32Pointer(app.ApplicationResponse.MaxRunningInstances),
+		AutoPreview:                 FromBoolPointer(app.ApplicationResponse.AutoPreview),
 		GitRepository:               convertResponseToApplicationGitRepository(app.ApplicationResponse.GitRepository),
 		Storage:                     convertResponseToApplicationStorage(app.ApplicationResponse.Storage),
 		Ports:                       convertResponseToApplicationPorts(app.ApplicationResponse.Ports),
@@ -192,11 +192,11 @@ func convertResponseToApplication(state Application, app *client.ApplicationResp
 		EnvironmentVariables:        fromEnvironmentVariableList(app.ApplicationEnvironmentVariables, qovery.APIVARIABLESCOPEENUM_APPLICATION).toTerraformSet(),
 		Secrets:                     fromSecretList(state.SecretList(), app.ApplicationSecrets, qovery.APIVARIABLESCOPEENUM_APPLICATION).toTerraformSet(),
 		CustomDomains:               fromCustomDomainList(app.ApplicationCustomDomains).toTerraformSet(),
-		InternalHost:                fromString(app.ApplicationInternalHost),
-		ExternalHost:                fromStringPointer(app.ApplicationExternalHost),
-		Entrypoint:                  fromStringPointer(app.ApplicationResponse.Entrypoint),
-		Arguments:                   fromStringArray(app.ApplicationResponse.Arguments),
-		DeploymentStageId:           fromString(app.ApplicationDeploymentStageID),
+		InternalHost:                FromString(app.ApplicationInternalHost),
+		ExternalHost:                FromStringPointer(app.ApplicationExternalHost),
+		Entrypoint:                  FromStringPointer(app.ApplicationResponse.Entrypoint),
+		Arguments:                   FromStringArray(app.ApplicationResponse.Arguments),
+		DeploymentStageId:           FromString(app.ApplicationDeploymentStageID),
 	}
 }
 
@@ -208,9 +208,9 @@ type ApplicationGitRepository struct {
 
 func (repo ApplicationGitRepository) toCreateRequest() qovery.ApplicationGitRepositoryRequest {
 	return qovery.ApplicationGitRepositoryRequest{
-		Url:      toString(repo.URL),
-		RootPath: toStringPointer(repo.RootPath),
-		Branch:   toStringPointer(repo.Branch),
+		Url:      ToString(repo.URL),
+		RootPath: ToStringPointer(repo.RootPath),
+		Branch:   ToStringPointer(repo.Branch),
 	}
 }
 
@@ -225,9 +225,9 @@ func convertResponseToApplicationGitRepository(gitRepository *qovery.Application
 	}
 
 	return &ApplicationGitRepository{
-		URL:      fromStringPointer(gitRepository.Url),
-		RootPath: fromStringPointer(gitRepository.RootPath),
-		Branch:   fromStringPointer(gitRepository.Branch),
+		URL:      FromStringPointer(gitRepository.Url),
+		RootPath: FromStringPointer(gitRepository.RootPath),
+		Branch:   FromStringPointer(gitRepository.Branch),
 	}
 }
 
@@ -239,20 +239,20 @@ type ApplicationStorage struct {
 }
 
 func (store ApplicationStorage) toCreateRequest() (*qovery.ServiceStorageRequestStorageInner, error) {
-	storageType, err := qovery.NewStorageTypeEnumFromValue(toString(store.Type))
+	storageType, err := qovery.NewStorageTypeEnumFromValue(ToString(store.Type))
 	if err != nil {
 		return nil, err
 	}
 
 	return &qovery.ServiceStorageRequestStorageInner{
 		Type:       *storageType,
-		Size:       toInt32(store.Size),
-		MountPoint: toString(store.MountPoint),
+		Size:       ToInt32(store.Size),
+		MountPoint: ToString(store.MountPoint),
 	}, nil
 }
 
 func (store ApplicationStorage) toUpdateRequest(id string) (*qovery.ServiceStorageRequestStorageInner, error) {
-	storageType, err := qovery.NewStorageTypeEnumFromValue(toString(store.Type))
+	storageType, err := qovery.NewStorageTypeEnumFromValue(ToString(store.Type))
 	if err != nil {
 		return nil, err
 	}
@@ -260,8 +260,8 @@ func (store ApplicationStorage) toUpdateRequest(id string) (*qovery.ServiceStora
 	return &qovery.ServiceStorageRequestStorageInner{
 		Id:         &id,
 		Type:       *storageType,
-		Size:       toInt32(store.Size),
-		MountPoint: toString(store.MountPoint),
+		Size:       ToInt32(store.Size),
+		MountPoint: ToString(store.MountPoint),
 	}, nil
 }
 
@@ -273,10 +273,10 @@ func convertResponseToApplicationStorage(storage []qovery.ServiceStorageStorageI
 	list := make([]ApplicationStorage, 0, len(storage))
 	for _, s := range storage {
 		list = append(list, ApplicationStorage{
-			Id:         fromString(s.Id),
+			Id:         FromString(s.Id),
 			Type:       fromClientEnum(s.Type),
-			Size:       fromInt32(s.Size),
-			MountPoint: fromString(s.MountPoint),
+			Size:       FromInt32(s.Size),
+			MountPoint: FromString(s.MountPoint),
 		})
 	}
 	return list
@@ -292,33 +292,33 @@ type ApplicationPort struct {
 }
 
 func (port ApplicationPort) toCreateRequest() (*qovery.ServicePortRequestPortsInner, error) {
-	protocol, err := qovery.NewPortProtocolEnumFromValue(toString(port.Protocol))
+	protocol, err := qovery.NewPortProtocolEnumFromValue(ToString(port.Protocol))
 	if err != nil {
 		return nil, err
 	}
 
 	return &qovery.ServicePortRequestPortsInner{
-		Name:               toStringPointer(port.Name),
-		InternalPort:       toInt32(port.InternalPort),
-		ExternalPort:       toInt32Pointer(port.ExternalPort),
+		Name:               ToStringPointer(port.Name),
+		InternalPort:       ToInt32(port.InternalPort),
+		ExternalPort:       ToInt32Pointer(port.ExternalPort),
 		Protocol:           protocol,
-		PubliclyAccessible: toBool(port.PubliclyAccessible),
+		PubliclyAccessible: ToBool(port.PubliclyAccessible),
 	}, nil
 }
 
 func (port ApplicationPort) toUpdateRequest() (*qovery.ServicePort, error) {
-	protocol, err := qovery.NewPortProtocolEnumFromValue(toString(port.Protocol))
+	protocol, err := qovery.NewPortProtocolEnumFromValue(ToString(port.Protocol))
 	if err != nil {
 		return nil, err
 	}
 
 	return &qovery.ServicePort{
-		Id:                 toString(port.Id),
-		Name:               toStringPointer(port.Name),
-		InternalPort:       toInt32(port.InternalPort),
-		ExternalPort:       toInt32Pointer(port.ExternalPort),
+		Id:                 ToString(port.Id),
+		Name:               ToStringPointer(port.Name),
+		InternalPort:       ToInt32(port.InternalPort),
+		ExternalPort:       ToInt32Pointer(port.ExternalPort),
 		Protocol:           *protocol,
-		PubliclyAccessible: toBool(port.PubliclyAccessible),
+		PubliclyAccessible: ToBool(port.PubliclyAccessible),
 	}, nil
 }
 
@@ -330,12 +330,12 @@ func convertResponseToApplicationPorts(ports []qovery.ServicePort) []Application
 	list := make([]ApplicationPort, 0, len(ports))
 	for _, p := range ports {
 		list = append(list, ApplicationPort{
-			Id:                 fromString(p.Id),
-			Name:               fromStringPointer(p.Name),
-			InternalPort:       fromInt32(p.InternalPort),
-			ExternalPort:       fromInt32Pointer(p.ExternalPort),
+			Id:                 FromString(p.Id),
+			Name:               FromStringPointer(p.Name),
+			InternalPort:       FromInt32(p.InternalPort),
+			ExternalPort:       FromInt32Pointer(p.ExternalPort),
 			Protocol:           fromClientEnum(p.Protocol),
-			PubliclyAccessible: fromBool(p.PubliclyAccessible),
+			PubliclyAccessible: FromBool(p.PubliclyAccessible),
 		})
 	}
 	return list

--- a/qovery/resource_aws_credentials_model.go
+++ b/qovery/resource_aws_credentials_model.go
@@ -22,17 +22,17 @@ type AWSCredentialsDataSource struct {
 
 func (creds AWSCredentials) toUpsertAwsRequest() credentials.UpsertAwsRequest {
 	return credentials.UpsertAwsRequest{
-		Name:            toString(creds.Name),
-		AccessKeyID:     toString(creds.AccessKeyId),
-		SecretAccessKey: toString(creds.SecretAccessKey),
+		Name:            ToString(creds.Name),
+		AccessKeyID:     ToString(creds.AccessKeyId),
+		SecretAccessKey: ToString(creds.SecretAccessKey),
 	}
 }
 
 func convertDomainCredentialsToAWSCredentials(creds *credentials.Credentials, plan AWSCredentials) AWSCredentials {
 	return AWSCredentials{
-		Id:              fromString(creds.ID.String()),
-		OrganizationId:  fromString(creds.OrganizationID.String()),
-		Name:            fromString(creds.Name),
+		Id:              FromString(creds.ID.String()),
+		OrganizationId:  FromString(creds.OrganizationID.String()),
+		Name:            FromString(creds.Name),
 		AccessKeyId:     plan.AccessKeyId,
 		SecretAccessKey: plan.SecretAccessKey,
 	}
@@ -40,8 +40,8 @@ func convertDomainCredentialsToAWSCredentials(creds *credentials.Credentials, pl
 
 func convertDomainCredentialsToAWSCredentialsDataSource(creds *credentials.Credentials) AWSCredentialsDataSource {
 	return AWSCredentialsDataSource{
-		Id:             fromString(creds.ID.String()),
-		OrganizationId: fromString(creds.OrganizationID.String()),
-		Name:           fromString(creds.Name),
+		Id:             FromString(creds.ID.String()),
+		OrganizationId: FromString(creds.OrganizationID.String()),
+		Name:           FromString(creds.Name),
 	}
 }

--- a/qovery/resource_cluster_model.go
+++ b/qovery/resource_cluster_model.go
@@ -91,7 +91,7 @@ func (c Cluster) hasRoutingTableDiff(state *Cluster) bool {
 }
 
 func (c Cluster) hasAdvSettingsDiff(state *Cluster) (bool, error) {
-	clusterSettings, clusterErr := toMapStringString(c.AdvancedSettings)
+	clusterSettings, clusterErr := ToMapStringString(c.AdvancedSettings)
 	if clusterErr != nil {
 		return false, clusterErr
 	}
@@ -99,7 +99,7 @@ func (c Cluster) hasAdvSettingsDiff(state *Cluster) (bool, error) {
 		return len(clusterSettings) > 0, nil
 	}
 
-	stateSettings, stateErr := toMapStringString(state.AdvancedSettings)
+	stateSettings, stateErr := ToMapStringString(state.AdvancedSettings)
 	if stateErr != nil {
 		return false, stateErr
 	}
@@ -111,12 +111,12 @@ func (c Cluster) hasAdvSettingsDiff(state *Cluster) (bool, error) {
 }
 
 func (c Cluster) toUpsertClusterRequest(state *Cluster) (*client.ClusterUpsertParams, error) {
-	cloudProvider, err := qovery.NewCloudProviderEnumFromValue(toString(c.CloudProvider))
+	cloudProvider, err := qovery.NewCloudProviderEnumFromValue(ToString(c.CloudProvider))
 	if err != nil {
 		return nil, err
 	}
 
-	kubernetesMode, err := qovery.NewKubernetesEnumFromValue(toString(c.KubernetesMode))
+	kubernetesMode, err := qovery.NewKubernetesEnumFromValue(ToString(c.KubernetesMode))
 	if err != nil {
 		return nil, err
 	}
@@ -127,10 +127,10 @@ func (c Cluster) toUpsertClusterRequest(state *Cluster) (*client.ClusterUpsertPa
 	if state == nil || c.CredentialsId != state.CredentialsId {
 		clusterCloudProviderRequest = &qovery.ClusterCloudProviderInfoRequest{
 			CloudProvider: cloudProvider,
-			Region:        toStringPointer(c.Region),
+			Region:        ToStringPointer(c.Region),
 			Credentials: &qovery.ClusterCloudProviderInfoCredentials{
-				Id:   toStringPointer(c.CredentialsId),
-				Name: toStringPointer(c.Name),
+				Id:   ToStringPointer(c.CredentialsId),
+				Name: ToStringPointer(c.Name),
 			},
 		}
 	}
@@ -142,12 +142,12 @@ func (c Cluster) toUpsertClusterRequest(state *Cluster) (*client.ClusterUpsertPa
 	}
 	forceUpdate := c.hasFeaturesDiff(state) || c.hasRoutingTableDiff(state) || advSettingsDiff
 
-	desiredState, err := qovery.NewStateEnumFromValue(toString(c.State))
+	desiredState, err := qovery.NewStateEnumFromValue(ToString(c.State))
 	if err != nil {
 		return nil, err
 	}
 
-	advSettings, parseErr := toMapStringString(c.AdvancedSettings)
+	advSettings, parseErr := ToMapStringString(c.AdvancedSettings)
 	if parseErr != nil {
 		return nil, parseErr
 	}
@@ -155,14 +155,14 @@ func (c Cluster) toUpsertClusterRequest(state *Cluster) (*client.ClusterUpsertPa
 	return &client.ClusterUpsertParams{
 		ClusterCloudProviderRequest: clusterCloudProviderRequest,
 		ClusterRequest: qovery.ClusterRequest{
-			Name:            toString(c.Name),
+			Name:            ToString(c.Name),
 			CloudProvider:   *cloudProvider,
-			Region:          toString(c.Region),
-			Description:     toStringPointer(c.Description),
+			Region:          ToString(c.Region),
+			Description:     ToStringPointer(c.Description),
 			Kubernetes:      kubernetesMode,
-			InstanceType:    toStringPointer(c.InstanceType),
-			MinRunningNodes: toInt32Pointer(c.MinRunningNodes),
-			MaxRunningNodes: toInt32Pointer(c.MaxRunningNodes),
+			InstanceType:    ToStringPointer(c.InstanceType),
+			MinRunningNodes: ToInt32Pointer(c.MinRunningNodes),
+			MaxRunningNodes: ToInt32Pointer(c.MaxRunningNodes),
 			Features:        toQoveryClusterFeatures(c.Features, c.KubernetesMode.String()),
 		},
 		ClusterRoutingTable:     routingTable.toUpsertRequest(),
@@ -176,21 +176,21 @@ func convertResponseToCluster(res *client.ClusterResponse) Cluster {
 	routingTable := fromClusterRoutingTable(res.ClusterRoutingTable)
 
 	return Cluster{
-		Id:               fromString(res.ClusterResponse.Id),
-		CredentialsId:    fromStringPointer(res.ClusterInfo.Credentials.Id),
-		OrganizationId:   fromString(res.OrganizationID),
-		Name:             fromString(res.ClusterResponse.Name),
+		Id:               FromString(res.ClusterResponse.Id),
+		CredentialsId:    FromStringPointer(res.ClusterInfo.Credentials.Id),
+		OrganizationId:   FromString(res.OrganizationID),
+		Name:             FromString(res.ClusterResponse.Name),
 		CloudProvider:    fromClientEnum(res.ClusterResponse.CloudProvider),
-		Region:           fromString(res.ClusterResponse.Region),
-		Description:      fromStringPointer(res.ClusterResponse.Description),
+		Region:           FromString(res.ClusterResponse.Region),
+		Description:      FromStringPointer(res.ClusterResponse.Description),
 		KubernetesMode:   fromClientEnumPointer(res.ClusterResponse.Kubernetes),
-		InstanceType:     fromStringPointer(res.ClusterResponse.InstanceType),
-		MinRunningNodes:  fromInt32Pointer(res.ClusterResponse.MinRunningNodes),
-		MaxRunningNodes:  fromInt32Pointer(res.ClusterResponse.MaxRunningNodes),
+		InstanceType:     FromStringPointer(res.ClusterResponse.InstanceType),
+		MinRunningNodes:  FromInt32Pointer(res.ClusterResponse.MinRunningNodes),
+		MaxRunningNodes:  FromInt32Pointer(res.ClusterResponse.MaxRunningNodes),
 		Features:         fromQoveryClusterFeatures(res.ClusterResponse.Features),
 		RoutingTables:    routingTable.toTerraformSet(),
 		State:            fromClientEnumPointer(res.ClusterResponse.Status),
-		AdvancedSettings: fromStringMap(res.ClusterAdvancedSetting),
+		AdvancedSettings: FromStringMap(res.ClusterAdvancedSetting),
 	}
 }
 
@@ -207,10 +207,10 @@ func fromQoveryClusterFeatures(ff []qovery.ClusterFeature) types.Object {
 		}
 		switch *f.Id {
 		case featureIdVpcSubnet:
-			attrs[featureKeyVpcSubnet] = fromStringPointer(f.GetValue().String)
+			attrs[featureKeyVpcSubnet] = FromStringPointer(f.GetValue().String)
 			attrTypes[featureKeyVpcSubnet] = types.StringType
 		case featureIdStaticIP:
-			attrs[featureKeyStaticIP] = fromBoolPointer(f.GetValue().Bool)
+			attrs[featureKeyStaticIP] = FromBoolPointer(f.GetValue().Bool)
 			attrTypes[featureKeyStaticIP] = types.BoolType
 		}
 	}
@@ -222,9 +222,9 @@ func fromQoveryClusterFeatures(ff []qovery.ClusterFeature) types.Object {
 		isNull = true
 		defaultFeatureKeyVpcSubnet := ""
 		defaultFeatureKeyStaticIP := false
-		attrs[featureKeyVpcSubnet] = fromStringPointer(&defaultFeatureKeyVpcSubnet)
+		attrs[featureKeyVpcSubnet] = FromStringPointer(&defaultFeatureKeyVpcSubnet)
 		attrTypes[featureKeyVpcSubnet] = types.StringType
-		attrs[featureKeyStaticIP] = fromBoolPointer(&defaultFeatureKeyStaticIP)
+		attrs[featureKeyStaticIP] = FromBoolPointer(&defaultFeatureKeyStaticIP)
 		attrTypes[featureKeyStaticIP] = types.BoolType
 	}
 
@@ -243,22 +243,22 @@ func toQoveryClusterFeatures(f types.Object, mode string) []qovery.ClusterReques
 	features := make([]qovery.ClusterRequestFeaturesInner, 0, len(f.Attrs))
 	if _, ok := f.Attrs[featureKeyVpcSubnet]; ok {
 		value := qovery.NewNullableClusterFeatureValue(&qovery.ClusterFeatureValue{
-			String: toStringPointer(f.Attrs[featureKeyVpcSubnet].(types.String)),
+			String: ToStringPointer(f.Attrs[featureKeyVpcSubnet].(types.String)),
 		})
 
 		features = append(features, qovery.ClusterRequestFeaturesInner{
-			Id:    stringAsPointer(featureIdVpcSubnet),
+			Id:    StringAsPointer(featureIdVpcSubnet),
 			Value: *value,
 		})
 	}
 
 	if _, ok := f.Attrs[featureKeyStaticIP]; ok {
 		value := qovery.NewNullableClusterFeatureValue(&qovery.ClusterFeatureValue{
-			Bool: toBoolPointer(f.Attrs[featureKeyStaticIP].(types.Bool)),
+			Bool: ToBoolPointer(f.Attrs[featureKeyStaticIP].(types.Bool)),
 		})
 
 		features = append(features, qovery.ClusterRequestFeaturesInner{
-			Id:    stringAsPointer(featureIdStaticIP),
+			Id:    StringAsPointer(featureIdStaticIP),
 			Value: *value,
 		})
 	}

--- a/qovery/resource_container_model.go
+++ b/qovery/resource_container_model.go
@@ -55,7 +55,7 @@ func (cont Container) PortList() PortList {
 }
 
 func (cont Container) ArgumentList() []string {
-	return toStringArray(cont.Arguments)
+	return ToStringArray(cont.Arguments)
 }
 
 //func (cont Container) CustomDomainsList() CustomDomainList {
@@ -100,44 +100,44 @@ func (cont Container) toUpsertRepositoryRequest() container.UpsertRepositoryRequ
 	}
 
 	return container.UpsertRepositoryRequest{
-		RegistryID:          toString(cont.RegistryID),
-		Name:                toString(cont.Name),
-		ImageName:           toString(cont.ImageName),
-		Tag:                 toString(cont.Tag),
-		AutoPreview:         toBoolPointer(cont.AutoPreview),
-		Entrypoint:          toStringPointer(cont.Entrypoint),
-		CPU:                 toInt32Pointer(cont.CPU),
-		Memory:              toInt32Pointer(cont.Memory),
-		MinRunningInstances: toInt32Pointer(cont.MinRunningInstances),
-		MaxRunningInstances: toInt32Pointer(cont.MaxRunningInstances),
+		RegistryID:          ToString(cont.RegistryID),
+		Name:                ToString(cont.Name),
+		ImageName:           ToString(cont.ImageName),
+		Tag:                 ToString(cont.Tag),
+		AutoPreview:         ToBoolPointer(cont.AutoPreview),
+		Entrypoint:          ToStringPointer(cont.Entrypoint),
+		CPU:                 ToInt32Pointer(cont.CPU),
+		Memory:              ToInt32Pointer(cont.Memory),
+		MinRunningInstances: ToInt32Pointer(cont.MinRunningInstances),
+		MaxRunningInstances: ToInt32Pointer(cont.MaxRunningInstances),
 		Arguments:           cont.ArgumentList(),
 		Storages:            storages,
 		Ports:               ports,
-		DeploymentStageID:   toString(cont.DeploymentStageId),
+		DeploymentStageID:   ToString(cont.DeploymentStageId),
 	}
 }
 
 func convertDomainContainerToContainer(state Container, container *container.Container) Container {
 	return Container{
-		ID:                          fromString(container.ID.String()),
-		EnvironmentID:               fromString(container.EnvironmentID.String()),
-		RegistryID:                  fromString(container.RegistryID.String()),
-		Name:                        fromString(container.Name),
-		ImageName:                   fromString(container.ImageName),
-		Tag:                         fromString(container.Tag),
-		CPU:                         fromInt32(container.CPU),
-		Memory:                      fromInt32(container.Memory),
-		MinRunningInstances:         fromInt32(container.MinRunningInstances),
-		MaxRunningInstances:         fromInt32(container.MaxRunningInstances),
-		AutoPreview:                 fromBool(container.AutoPreview),
-		Arguments:                   fromStringArray(container.Arguments),
+		ID:                          FromString(container.ID.String()),
+		EnvironmentID:               FromString(container.EnvironmentID.String()),
+		RegistryID:                  FromString(container.RegistryID.String()),
+		Name:                        FromString(container.Name),
+		ImageName:                   FromString(container.ImageName),
+		Tag:                         FromString(container.Tag),
+		CPU:                         FromInt32(container.CPU),
+		Memory:                      FromInt32(container.Memory),
+		MinRunningInstances:         FromInt32(container.MinRunningInstances),
+		MaxRunningInstances:         FromInt32(container.MaxRunningInstances),
+		AutoPreview:                 FromBool(container.AutoPreview),
+		Arguments:                   FromStringArray(container.Arguments),
 		Storages:                    convertDomainStoragesToStorageList(container.Storages).toTerraformSet(),
 		Ports:                       convertDomainPortsToPortList(container.Ports).toTerraformSet(),
 		EnvironmentVariables:        convertDomainVariablesToEnvironmentVariableList(container.EnvironmentVariables, variable.ScopeContainer).toTerraformSet(),
 		BuiltInEnvironmentVariables: convertDomainVariablesToEnvironmentVariableList(container.BuiltInEnvironmentVariables, variable.ScopeBuiltIn).toTerraformSet(),
-		InternalHost:                fromStringPointer(container.InternalHost),
-		ExternalHost:                fromStringPointer(container.ExternalHost),
+		InternalHost:                FromStringPointer(container.InternalHost),
+		ExternalHost:                FromStringPointer(container.ExternalHost),
 		Secrets:                     convertDomainSecretsToSecretList(state.SecretList(), container.Secrets, variable.ScopeContainer).toTerraformSet(),
-		DeploymentStageId:           fromString(container.DeploymentStageID),
+		DeploymentStageId:           FromString(container.DeploymentStageID),
 	}
 }

--- a/qovery/resource_container_registry_model.go
+++ b/qovery/resource_container_registry_model.go
@@ -41,43 +41,43 @@ func (p ContainerRegistry) toUpsertRequest() registry.UpsertRequest {
 		configRequest = registry.UpsertRequestConfig{}
 	} else {
 		configRequest = registry.UpsertRequestConfig{
-			AccessKeyID:       toStringPointer(p.Config.AccessKeyID),
-			SecretAccessKey:   toStringPointer(p.Config.SecretAccessKey),
-			Region:            toStringPointer(p.Config.Region),
-			ScalewayAccessKey: toStringPointer(p.Config.ScalewayAccessKey),
-			ScalewaySecretKey: toStringPointer(p.Config.ScalewaySecretKey),
-			Username:          toStringPointer(p.Config.Username),
-			Password:          toStringPointer(p.Config.Password),
+			AccessKeyID:       ToStringPointer(p.Config.AccessKeyID),
+			SecretAccessKey:   ToStringPointer(p.Config.SecretAccessKey),
+			Region:            ToStringPointer(p.Config.Region),
+			ScalewayAccessKey: ToStringPointer(p.Config.ScalewayAccessKey),
+			ScalewaySecretKey: ToStringPointer(p.Config.ScalewaySecretKey),
+			Username:          ToStringPointer(p.Config.Username),
+			Password:          ToStringPointer(p.Config.Password),
 		}
 	}
 	return registry.UpsertRequest{
-		Name:        toString(p.Name),
-		Kind:        toString(p.Kind),
-		URL:         toString(p.URL),
-		Description: toStringPointer(p.Description),
+		Name:        ToString(p.Name),
+		Kind:        ToString(p.Kind),
+		URL:         ToString(p.URL),
+		Description: ToStringPointer(p.Description),
 		Config:      configRequest,
 	}
 }
 
 func convertDomainRegistryToContainerRegistry(state ContainerRegistry, res *registry.Registry) ContainerRegistry {
 	return ContainerRegistry{
-		Id:             fromString(res.ID.String()),
-		OrganizationId: fromString(res.OrganizationID.String()),
-		Name:           fromString(res.Name),
-		Kind:           fromString(res.Kind.String()),
-		URL:            fromString(res.URL.String()),
-		Description:    fromStringPointer(res.Description),
+		Id:             FromString(res.ID.String()),
+		OrganizationId: FromString(res.OrganizationID.String()),
+		Name:           FromString(res.Name),
+		Kind:           FromString(res.Kind.String()),
+		URL:            FromString(res.URL.String()),
+		Description:    FromStringPointer(res.Description),
 		Config:         state.Config,
 	}
 }
 
 func convertDomainRegistryToContainerRegistryDataSource(res *registry.Registry) ContainerRegistryDataSource {
 	return ContainerRegistryDataSource{
-		Id:             fromString(res.ID.String()),
-		OrganizationId: fromString(res.OrganizationID.String()),
-		Name:           fromString(res.Name),
-		Kind:           fromString(res.Kind.String()),
-		URL:            fromString(res.URL.String()),
-		Description:    fromStringPointer(res.Description),
+		Id:             FromString(res.ID.String()),
+		OrganizationId: FromString(res.OrganizationID.String()),
+		Name:           FromString(res.Name),
+		Kind:           FromString(res.Kind.String()),
+		URL:            FromString(res.URL.String()),
+		Description:    FromStringPointer(res.Description),
 	}
 }

--- a/qovery/resource_database_model.go
+++ b/qovery/resource_database_model.go
@@ -27,71 +27,71 @@ type Database struct {
 }
 
 func (d Database) toCreateDatabaseRequest() (*client.DatabaseCreateParams, error) {
-	dbType, err := qovery.NewDatabaseTypeEnumFromValue(toString(d.Type))
+	dbType, err := qovery.NewDatabaseTypeEnumFromValue(ToString(d.Type))
 	if err != nil {
 		return nil, err
 	}
 
-	mode, err := qovery.NewDatabaseModeEnumFromValue(toString(d.Mode))
+	mode, err := qovery.NewDatabaseModeEnumFromValue(ToString(d.Mode))
 	if err != nil {
 		return nil, err
 	}
 
-	accessibility, err := qovery.NewDatabaseAccessibilityEnumFromValue(toString(d.Accessibility))
+	accessibility, err := qovery.NewDatabaseAccessibilityEnumFromValue(ToString(d.Accessibility))
 	if err != nil {
 		return nil, err
 	}
 
 	return &client.DatabaseCreateParams{
 		DatabaseRequest: qovery.DatabaseRequest{
-			Name:          toString(d.Name),
+			Name:          ToString(d.Name),
 			Type:          *dbType,
-			Version:       toString(d.Version),
+			Version:       ToString(d.Version),
 			Mode:          *mode,
 			Accessibility: accessibility,
-			Cpu:           toInt32Pointer(d.CPU),
-			Memory:        toInt32Pointer(d.Memory),
-			Storage:       toInt32Pointer(d.Storage),
+			Cpu:           ToInt32Pointer(d.CPU),
+			Memory:        ToInt32Pointer(d.Memory),
+			Storage:       ToInt32Pointer(d.Storage),
 		},
-		DeploymentStageID: toString(d.DeploymentStageId),
+		DeploymentStageID: ToString(d.DeploymentStageId),
 	}, nil
 }
 
 func (d Database) toUpdateDatabaseRequest() (*client.DatabaseUpdateParams, error) {
-	accessibility, err := qovery.NewDatabaseAccessibilityEnumFromValue(toString(d.Accessibility))
+	accessibility, err := qovery.NewDatabaseAccessibilityEnumFromValue(ToString(d.Accessibility))
 	if err != nil {
 		return nil, err
 	}
 
 	return &client.DatabaseUpdateParams{
 		DatabaseEditRequest: qovery.DatabaseEditRequest{
-			Name:          toStringPointer(d.Name),
-			Version:       toStringPointer(d.Version),
+			Name:          ToStringPointer(d.Name),
+			Version:       ToStringPointer(d.Version),
 			Accessibility: accessibility,
-			Cpu:           toInt32Pointer(d.CPU),
-			Memory:        toInt32Pointer(d.Memory),
-			Storage:       toInt32Pointer(d.Storage),
+			Cpu:           ToInt32Pointer(d.CPU),
+			Memory:        ToInt32Pointer(d.Memory),
+			Storage:       ToInt32Pointer(d.Storage),
 		},
 	}, nil
 }
 
 func convertResponseToDatabase(res *client.DatabaseResponse) Database {
 	return Database{
-		Id:                fromString(res.DatabaseResponse.Id),
-		EnvironmentId:     fromString(res.DatabaseResponse.Environment.Id),
-		Name:              fromString(res.DatabaseResponse.Name),
+		Id:                FromString(res.DatabaseResponse.Id),
+		EnvironmentId:     FromString(res.DatabaseResponse.Environment.Id),
+		Name:              FromString(res.DatabaseResponse.Name),
 		Type:              fromClientEnum(res.DatabaseResponse.Type),
-		Version:           fromString(res.DatabaseResponse.Version),
+		Version:           FromString(res.DatabaseResponse.Version),
 		Mode:              fromClientEnum(res.DatabaseResponse.Mode),
 		Accessibility:     fromClientEnumPointer(res.DatabaseResponse.Accessibility),
-		CPU:               fromInt32Pointer(res.DatabaseResponse.Cpu),
-		Memory:            fromInt32Pointer(res.DatabaseResponse.Memory),
-		ExternalHost:      fromString(res.DatabaseResponse.GetHost()),
-		InternalHost:      fromString(res.DatabaseInternalHost),
-		Port:              fromInt32Pointer(res.DatabaseResponse.Port),
-		Login:             fromString(res.DatabaseCredentials.Login),
-		Password:          fromString(res.DatabaseCredentials.Password),
-		Storage:           fromInt32Pointer(res.DatabaseResponse.Storage),
-		DeploymentStageId: fromString(res.DeploymentStageID),
+		CPU:               FromInt32Pointer(res.DatabaseResponse.Cpu),
+		Memory:            FromInt32Pointer(res.DatabaseResponse.Memory),
+		ExternalHost:      FromString(res.DatabaseResponse.GetHost()),
+		InternalHost:      FromString(res.DatabaseInternalHost),
+		Port:              FromInt32Pointer(res.DatabaseResponse.Port),
+		Login:             FromString(res.DatabaseCredentials.Login),
+		Password:          FromString(res.DatabaseCredentials.Password),
+		Storage:           FromInt32Pointer(res.DatabaseResponse.Storage),
+		DeploymentStageId: FromString(res.DeploymentStageID),
 	}
 }

--- a/qovery/resource_deployment.go
+++ b/qovery/resource_deployment.go
@@ -49,10 +49,10 @@ func newDeploymentTerraformFromDomain(domain *newdeployment.Deployment) NewDeplo
 		version = &versionToString
 	}
 	return NewDeploymentTerraform{
-		Id:            fromString(domain.ID.String()),
-		EnvironmentId: fromString(domain.EnvironmentID.String()),
-		Version:       fromStringPointer(version),
-		DesiredState:  fromString(domain.DesiredState.String()),
+		Id:            FromString(domain.ID.String()),
+		EnvironmentId: FromString(domain.EnvironmentID.String()),
+		Version:       FromStringPointer(version),
+		DesiredState:  FromString(domain.DesiredState.String()),
 	}
 }
 
@@ -125,10 +125,10 @@ func (r deploymentResource) Create(ctx context.Context, req resource.CreateReque
 
 	// Create new deployment stage
 	deployment, err := r.deploymentService.Create(ctx, newdeployment.NewDeploymentParams{
-		ID:            toStringPointer(plan.Id),
-		EnvironmentID: toString(plan.EnvironmentId),
-		Version:       toStringPointer(plan.Version),
-		DesiredState:  toString(plan.DesiredState),
+		ID:            ToStringPointer(plan.Id),
+		EnvironmentID: ToString(plan.EnvironmentId),
+		Version:       ToStringPointer(plan.Version),
+		DesiredState:  ToString(plan.DesiredState),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Error on deployment create", err.Error())
@@ -151,10 +151,10 @@ func (r deploymentResource) Read(ctx context.Context, req resource.ReadRequest, 
 	}
 
 	deployment, err := r.deploymentService.Get(ctx, newdeployment.NewDeploymentParams{
-		ID:            toStringPointer(state.Id),
-		EnvironmentID: toString(state.EnvironmentId),
-		Version:       toStringPointer(state.Version),
-		DesiredState:  toString(state.DesiredState),
+		ID:            ToStringPointer(state.Id),
+		EnvironmentID: ToString(state.EnvironmentId),
+		Version:       ToStringPointer(state.Version),
+		DesiredState:  ToString(state.DesiredState),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Error on deployment read", err.Error())
@@ -177,10 +177,10 @@ func (r deploymentResource) Update(ctx context.Context, req resource.UpdateReque
 	}
 
 	deployment, err := r.deploymentService.Update(ctx, newdeployment.NewDeploymentParams{
-		ID:            toStringPointer(state.Id),
-		EnvironmentID: toString(plan.EnvironmentId),
-		Version:       toStringPointer(plan.Version),
-		DesiredState:  toString(plan.DesiredState),
+		ID:            ToStringPointer(state.Id),
+		EnvironmentID: ToString(plan.EnvironmentId),
+		Version:       ToStringPointer(plan.Version),
+		DesiredState:  ToString(plan.DesiredState),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Error on deployment update", err.Error())
@@ -201,7 +201,7 @@ func (r deploymentResource) Delete(ctx context.Context, req resource.DeleteReque
 	}
 
 	err := r.deploymentService.Delete(ctx, newdeployment.NewDeploymentParams{
-		EnvironmentID: toString(state.EnvironmentId),
+		EnvironmentID: ToString(state.EnvironmentId),
 		// When terraform destroys, the desired state will be "DELETED"
 		DesiredState: "DELETED",
 	})

--- a/qovery/resource_deployment_stage_model.go
+++ b/qovery/resource_deployment_stage_model.go
@@ -18,10 +18,10 @@ type DeploymentStage struct {
 func (p DeploymentStage) toCreateServiceRequest() deploymentstage.UpsertServiceRequest {
 	return deploymentstage.UpsertServiceRequest{
 		DeploymentStageUpsertRequest: deploymentstage.UpsertRepositoryRequest{
-			Name:        toString(p.Name),
-			Description: toString(p.Description),
-			MoveAfter:   toStringPointer(p.MoveAfter),
-			MoveBefore:  toStringPointer(p.MoveBefore),
+			Name:        ToString(p.Name),
+			Description: ToString(p.Description),
+			MoveAfter:   ToStringPointer(p.MoveAfter),
+			MoveBefore:  ToStringPointer(p.MoveBefore),
 		},
 	}
 }
@@ -29,10 +29,10 @@ func (p DeploymentStage) toCreateServiceRequest() deploymentstage.UpsertServiceR
 func (p DeploymentStage) toUpdateServiceRequest() deploymentstage.UpsertServiceRequest {
 	return deploymentstage.UpsertServiceRequest{
 		DeploymentStageUpsertRequest: deploymentstage.UpsertRepositoryRequest{
-			Name:        toString(p.Name),
-			Description: toString(p.Description),
-			MoveAfter:   toStringPointer(p.MoveAfter),
-			MoveBefore:  toStringPointer(p.MoveBefore),
+			Name:        ToString(p.Name),
+			Description: ToString(p.Description),
+			MoveAfter:   ToStringPointer(p.MoveAfter),
+			MoveBefore:  ToStringPointer(p.MoveBefore),
 		},
 	}
 }
@@ -56,11 +56,11 @@ func convertDomainDeploymentStageToDeploymentStage(deploymentStageDomain *deploy
 	}
 
 	return DeploymentStage{
-		Id:            fromString(deploymentStageDomain.ID.String()),
-		EnvironmentId: fromString(deploymentStageDomain.EnvironmentID.String()),
-		Name:          fromString(deploymentStageDomain.Name),
-		Description:   fromStringPointer(description),
-		MoveAfter:     fromStringPointer(moveAfterString),
-		MoveBefore:    fromStringPointer(moveBeforeString),
+		Id:            FromString(deploymentStageDomain.ID.String()),
+		EnvironmentId: FromString(deploymentStageDomain.EnvironmentID.String()),
+		Name:          FromString(deploymentStageDomain.Name),
+		Description:   FromStringPointer(description),
+		MoveAfter:     FromStringPointer(moveAfterString),
+		MoveBefore:    FromStringPointer(moveBeforeString),
 	}
 }

--- a/qovery/resource_docker_model.go
+++ b/qovery/resource_docker_model.go
@@ -1,15 +1,18 @@
 package qovery
 
-import "github.com/qovery/terraform-provider-qovery/internal/domain/docker"
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/qovery/terraform-provider-qovery/internal/domain/docker"
+)
 
 type Docker struct {
 	GitRepository  GitRepository `tfsdk:"git_repository"`
-	DockerFilePath *string       `tfsdk:"dockerfile_path"`
+	DockerFilePath types.String  `tfsdk:"dockerfile_path"`
 }
 
 func (d Docker) toUpsertRequest() *docker.Docker {
 	return &docker.Docker{
 		GitRepository:  d.GitRepository.toUpsertRequest(),
-		DockerFilePath: d.DockerFilePath,
+		DockerFilePath: ToStringPointer(d.DockerFilePath),
 	}
 }

--- a/qovery/resource_environment_model.go
+++ b/qovery/resource_environment_model.go
@@ -31,15 +31,15 @@ func (e Environment) SecretList() SecretList {
 }
 
 func (e Environment) toCreateEnvironmentRequest() (*environment.CreateServiceRequest, error) {
-	mode, err := environment.NewModeFromString(toString(e.Mode))
+	mode, err := environment.NewModeFromString(ToString(e.Mode))
 	if err != nil {
 		return nil, err
 	}
 
 	return &environment.CreateServiceRequest{
 		EnvironmentCreateRequest: environment.CreateRepositoryRequest{
-			Name:      toString(e.Name),
-			ClusterID: toStringPointer(e.ClusterId),
+			Name:      ToString(e.Name),
+			ClusterID: ToStringPointer(e.ClusterId),
 			Mode:      mode,
 		},
 		EnvironmentVariables: e.EnvironmentVariableList().diffRequest(nil),
@@ -50,7 +50,7 @@ func (e Environment) toCreateEnvironmentRequest() (*environment.CreateServiceReq
 func (e Environment) toUpdateEnvironmentRequest(state Environment) (*environment.UpdateServiceRequest, error) {
 	var mode *environment.Mode
 	if !e.Mode.IsNull() {
-		m, err := environment.NewModeFromString(toString(e.Mode))
+		m, err := environment.NewModeFromString(ToString(e.Mode))
 		if err != nil {
 			return nil, err
 		}
@@ -59,7 +59,7 @@ func (e Environment) toUpdateEnvironmentRequest(state Environment) (*environment
 
 	return &environment.UpdateServiceRequest{
 		EnvironmentUpdateRequest: environment.UpdateRepositoryRequest{
-			Name: toStringPointer(e.Name),
+			Name: ToStringPointer(e.Name),
 			Mode: mode,
 		},
 		EnvironmentVariables: e.EnvironmentVariableList().diffRequest(state.EnvironmentVariableList()),
@@ -69,10 +69,10 @@ func (e Environment) toUpdateEnvironmentRequest(state Environment) (*environment
 
 func convertDomainEnvironmentToEnvironment(state Environment, env *environment.Environment) Environment {
 	return Environment{
-		Id:                          fromString(env.ID.String()),
-		ProjectId:                   fromString(env.ProjectID.String()),
-		ClusterId:                   fromString(env.ClusterID.String()),
-		Name:                        fromString(env.Name),
+		Id:                          FromString(env.ID.String()),
+		ProjectId:                   FromString(env.ProjectID.String()),
+		ClusterId:                   FromString(env.ClusterID.String()),
+		Name:                        FromString(env.Name),
 		Mode:                        fromClientEnum(env.Mode),
 		EnvironmentVariables:        convertDomainVariablesToEnvironmentVariableList(env.EnvironmentVariables, variable.ScopeEnvironment).toTerraformSet(),
 		BuiltInEnvironmentVariables: convertDomainVariablesToEnvironmentVariableList(env.BuiltInEnvironmentVariables, variable.ScopeBuiltIn).toTerraformSet(),

--- a/qovery/resource_execution_command_model.go
+++ b/qovery/resource_execution_command_model.go
@@ -1,6 +1,8 @@
 package qovery
 
+import "github.com/hashicorp/terraform-plugin-framework/types"
+
 type ExecutionCommand struct {
-	Entrypoint *string  `tfsdk:"entrypoint"`
-	Arguments  []string `tfsdk:"arguments"`
+	Entrypoint types.String   `tfsdk:"entrypoint"`
+	Arguments  []types.String `tfsdk:"arguments"`
 }

--- a/qovery/resource_git_repository_model.go
+++ b/qovery/resource_git_repository_model.go
@@ -1,17 +1,32 @@
 package qovery
 
-import "github.com/qovery/terraform-provider-qovery/internal/domain/git_repository"
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/qovery/terraform-provider-qovery/internal/domain/git_repository"
+)
 
 type GitRepository struct {
-	Url      string  `tfsdk:"url"`
-	Branch   *string `tfsdk:"branch"`
-	RootPath *string `tfsdk:"root_path"`
+	Url      types.String `tfsdk:"url"`
+	Branch   types.String `tfsdk:"branch"`
+	RootPath types.String `tfsdk:"root_path"`
 }
 
 func (g GitRepository) toUpsertRequest() git_repository.GitRepository {
+	var branch *string = nil
+	if !g.Branch.IsNull() {
+		v := g.Branch.String()
+		branch = &v
+	}
+
+	var rootPath *string = nil
+	if !g.RootPath.IsNull() {
+		v := g.RootPath.String()
+		rootPath = &v
+	}
+
 	return git_repository.GitRepository{
-		Url:      g.Url,
-		Branch:   g.Branch,
-		RootPath: g.RootPath,
+		Url:      g.Url.String(),
+		Branch:   branch,
+		RootPath: rootPath,
 	}
 }

--- a/qovery/resource_image_model.go
+++ b/qovery/resource_image_model.go
@@ -13,8 +13,8 @@ type Image struct {
 
 func (i Image) toUpsertRequest() *image.Image {
 	return &image.Image{
-		RegistryID: toString(i.RegistryID),
-		Name:       toString(i.Name),
-		Tag:        toString(i.Tag),
+		RegistryID: ToString(i.RegistryID),
+		Name:       ToString(i.Name),
+		Tag:        ToString(i.Tag),
 	}
 }

--- a/qovery/resource_job_test.go
+++ b/qovery/resource_job_test.go
@@ -21,10 +21,9 @@ import (
 )
 
 const (
-	jobImageName                     = "terraform-provider-tests-job"
-	jobImageTag                      = "1.0.0"
-	jobScheduleCronString            = "*/2 * * * *"
-	jobScheduleCronCommandEntrypoint = ""
+	jobImageName          = "terraform-provider-tests-job"
+	jobImageTag           = "1.0.0"
+	jobScheduleCronString = "*/2 * * * *"
 )
 
 func TestAcc_Job(t *testing.T) {
@@ -153,70 +152,6 @@ func TestAcc_Job(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccJobDefaultConfig(testName string) string {
-	return fmt.Sprintf(`
-%s
-
-%s
-
-resource "qovery_job" "test" {
-  environment_id = qovery_environment.test.id
-  name = "%s"
-
-  source = {
-    image = {
-      registry_id = qovery_container_registry.test.id
-      name = "%s"
-      tag = "%s"
-    }
-  }
-
-  schedule = {
-    cronjob = {
-      schedule = "%s"
-        command = {
-          entrypoint = "%s"
-          arguments = []
-        }
-      }
-    }
-}
-`, testAccEnvironmentDefaultConfig(testName), testAccContainerRegistryDefaultConfig(testName), generateTestName(testName),
-		jobImageName, jobImageTag, jobScheduleCronString, jobScheduleCronCommandEntrypoint)
-}
-
-func testAccJobDefaultConfigWithName(testName string, name string) string {
-	return fmt.Sprintf(`
-%s
-
-%s
-
-resource "qovery_job" "test" {
-  environment_id = qovery_environment.test.id
-  name = "%s"
-
-  source = {
-    image = {
-      registry_id = qovery_container_registry.test.id
-      name = "%s"
-      tag = "%s"
-    }
-  }
-
-  schedule = {
-    cronjob = {
-      schedule = "%s"
-        command = {
-          entrypoint = "%s"
-          arguments = []
-        }
-      }
-    }
-}
-`, testAccEnvironmentDefaultConfig(testName), testAccContainerRegistryDefaultConfig(testName), name,
-		jobImageName, jobImageTag, jobScheduleCronString, jobScheduleCronCommandEntrypoint)
 }
 
 func getJobConfigFromModel(testName string, job qovery.Job) string {

--- a/qovery/resource_job_test.go
+++ b/qovery/resource_job_test.go
@@ -4,16 +4,20 @@
 package qovery_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"regexp"
 	"testing"
+	"text/template"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/pkg/errors"
 
 	"github.com/qovery/terraform-provider-qovery/internal/domain/apierrors"
+	"github.com/qovery/terraform-provider-qovery/qovery"
 )
 
 const (
@@ -33,8 +37,31 @@ func TestAcc_Job(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccJobDefaultConfig(
+				Config: getJobConfigFromModel(
 					testName,
+					qovery.Job{
+						Name:               qovery.FromString(generateTestName(testName)),
+						AutoPreview:        qovery.FromBool(false),
+						CPU:                qovery.FromInt32(500),
+						Memory:             qovery.FromInt32(512),
+						MaxDurationSeconds: qovery.FromUInt32(300),
+						MaxNbRestart:       qovery.FromUInt32(0),
+						Port:               qovery.FromInt32Pointer(nil),
+						Source: &qovery.JobSource{
+							Image: &qovery.Image{
+								Name: qovery.FromString(jobImageName),
+								Tag:  qovery.FromString(jobImageTag),
+							},
+						},
+						Schedule: &qovery.JobSchedule{
+							CronJob: &qovery.JobScheduleCron{
+								Schedule: qovery.FromString(jobScheduleCronString),
+								Command:  qovery.ExecutionCommand{},
+							},
+						},
+						EnvironmentVariables: types.Set{Null: true},
+						Secrets:              types.Set{Null: true},
+					},
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccQoveryProjectExists("qovery_project.test"),
@@ -65,16 +92,38 @@ func TestAcc_Job(t *testing.T) {
 			},
 			// Update name
 			{
-				Config: testAccJobDefaultConfigWithName(
+				Config: getJobConfigFromModel(
 					testName,
-					fmt.Sprintf("%s-updated", testName),
+					qovery.Job{
+						Name:               qovery.FromString(generateTestName(testName) + "-updated"),
+						AutoPreview:        qovery.FromBool(false),
+						CPU:                qovery.FromInt32(500),
+						Memory:             qovery.FromInt32(512),
+						MaxDurationSeconds: qovery.FromUInt32(300),
+						MaxNbRestart:       qovery.FromUInt32(0),
+						Port:               qovery.FromInt32Pointer(nil),
+						Source: &qovery.JobSource{
+							Image: &qovery.Image{
+								Name: qovery.FromString(jobImageName),
+								Tag:  qovery.FromString(jobImageTag),
+							},
+						},
+						Schedule: &qovery.JobSchedule{
+							CronJob: &qovery.JobScheduleCron{
+								Schedule: qovery.FromString(jobScheduleCronString),
+								Command:  qovery.ExecutionCommand{},
+							},
+						},
+						EnvironmentVariables: types.Set{Null: true},
+						Secrets:              types.Set{Null: true},
+					},
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccQoveryProjectExists("qovery_project.test"),
 					testAccQoveryEnvironmentExists("qovery_environment.test"),
 					testAccQoveryContainerRegistryExists("qovery_container_registry.test"),
 					testAccQoveryJobExists("qovery_job.test"),
-					resource.TestCheckResourceAttr("qovery_job.test", "name", fmt.Sprintf("%s-updated", testName)),
+					resource.TestCheckResourceAttr("qovery_job.test", "name", fmt.Sprintf("%s-updated", generateTestName(testName))),
 					resource.TestCheckResourceAttr("qovery_job.test", "auto_preview", "false"),
 					resource.TestCheckResourceAttr("qovery_job.test", "cpu", "500"),
 					resource.TestCheckResourceAttr("qovery_job.test", "memory", "512"),
@@ -168,6 +217,124 @@ resource "qovery_job" "test" {
 }
 `, testAccEnvironmentDefaultConfig(testName), testAccContainerRegistryDefaultConfig(testName), name,
 		jobImageName, jobImageTag, jobScheduleCronString, jobScheduleCronCommandEntrypoint)
+}
+
+func getJobConfigFromModel(testName string, job qovery.Job) string {
+	tmpl_model := struct {
+		EnvironmentStr       string
+		ContainerRegistryStr string
+		Job                  qovery.Job
+	}{
+		EnvironmentStr:       testAccEnvironmentDefaultConfig(testName),
+		ContainerRegistryStr: testAccContainerRegistryDefaultConfig(testName),
+		Job:                  job,
+	}
+
+	tmpl, err := template.New("getJobConfigFromModel").Parse(`
+{{ .EnvironmentStr }}
+
+{{ .ContainerRegistryStr }}
+
+resource "qovery_job" "test" {
+  environment_id = qovery_environment.test.id
+  name = {{ .Job.Name.String }}
+
+  cpu = {{ .Job.CPU }}
+  memory = {{ .Job.Memory }}
+  max_duration_seconds = {{ .Job.MaxDurationSeconds }}
+  max_nb_restart = {{ .Job.MaxNbRestart }}
+  auto_preview = {{ .Job.AutoPreview }}
+
+  {{ if not .Job.EnvironmentVariables.IsNull }}
+  environment_variables = {{ .Job.EnvironmentVariables.String }}
+  {{ end }}
+
+  {{ if not .Job.Secrets.IsNull }}	
+  secrets = {{ .Job.Secrets.String }}	
+  {{ end }}
+
+  {{ with .Job.Source }}	
+  source = {
+	{{ with .Image }}	
+    image = {
+      registry_id = qovery_container_registry.test.id
+      name = {{ .Name.String }}
+      tag = {{ .Tag.String }}
+    }
+    {{ end }}
+	{{ with .Docker }}	
+	docker = {
+        {{ with .DockerDockerFilePath }}	
+		dockerfile_path = {{ .String }}
+        {{ end }}
+		{{ with .GitRepository }}
+		git_repository = {
+			{{ with .Url }}
+        	url = {{ .String }}
+			{{ end }}
+			{{ with .Branch }}
+        	branch = {{ .String }}
+			{{ end }}
+			{{ with .RootPath }}	
+        	root_path = {{ .String }}
+			{{ end }}
+        }
+		{{ end }}
+	}
+    {{ end }}
+  }
+  {{ end }}
+
+  {{ with .Job.Schedule }}	
+  schedule = {
+	{{ with .OnStart }}
+    on_start = {
+      {{ with .Entrypoint }}
+	  entrypoint = {{ .String }}
+	  {{ end }}
+	  arguments = [{{ range .Arguments }} {{ .String }} {{ end }}]
+    }
+    {{ end }}
+    {{ with .OnStop }}
+    on_stop = {
+      {{ with .Entrypoint }}
+	  entrypoint = {{ .String }}
+	  {{ end }}
+	  arguments = [{{ range .Arguments }} {{ .String }} {{ end }}]
+    }
+    {{ end }}
+    {{ with .OnDelete }}
+    on_delete = {
+      {{ with .Entrypoint }}
+	  entrypoint = {{ .String }}
+	  {{ end }}
+	  arguments = [{{ range .Arguments }} {{ .String }} {{ end }}]
+    }
+    {{ end }}
+	{{ with .CronJob }}	
+    cronjob = {
+      schedule = {{ .Schedule.String }}
+      command = {
+        {{ with .Command.Entrypoint }}
+        entrypoint = {{ .String }}
+        {{ end }}
+        arguments = [{{ range .Command.Arguments }} {{ .String }} {{ end }}]
+      }
+    }
+    {{ end }}
+  }
+  {{ end }}
+}
+
+`)
+
+	var jobConfigStr bytes.Buffer
+	err = tmpl.Execute(&jobConfigStr, tmpl_model)
+	if err != nil {
+		return ""
+	}
+
+	return jobConfigStr.String()
 }
 
 func testAccQoveryJobExists(resourceName string) resource.TestCheckFunc {

--- a/qovery/resource_organization_model.go
+++ b/qovery/resource_organization_model.go
@@ -15,16 +15,16 @@ type Organization struct {
 
 func (org Organization) toOrganizationUpdateRequest() organization.UpdateRequest {
 	return organization.UpdateRequest{
-		Name:        toString(org.Name),
-		Description: toStringPointer(org.Description),
+		Name:        ToString(org.Name),
+		Description: ToStringPointer(org.Description),
 	}
 }
 
 func convertDomainOrganizationToTerraform(organization *organization.Organization) Organization {
 	return Organization{
-		Id:          fromString(organization.ID.String()),
-		Name:        fromString(organization.Name),
+		Id:          FromString(organization.ID.String()),
+		Name:        FromString(organization.Name),
 		Plan:        fromClientEnum(organization.Plan),
-		Description: fromStringPointer(organization.Description),
+		Description: FromStringPointer(organization.Description),
 	}
 }

--- a/qovery/resource_project_model.go
+++ b/qovery/resource_project_model.go
@@ -32,8 +32,8 @@ func (p Project) SecretList() SecretList {
 func (p Project) toCreateServiceRequest() project.UpsertServiceRequest {
 	return project.UpsertServiceRequest{
 		ProjectUpsertRequest: project.UpsertRepositoryRequest{
-			Name:        toString(p.Name),
-			Description: toStringPointer(p.Description),
+			Name:        ToString(p.Name),
+			Description: ToStringPointer(p.Description),
 		},
 		EnvironmentVariables: p.EnvironmentVariableList().diffRequest(nil),
 		Secrets:              p.SecretList().diffRequest(nil),
@@ -43,8 +43,8 @@ func (p Project) toCreateServiceRequest() project.UpsertServiceRequest {
 func (p Project) toUpdateServiceRequest(state Project) project.UpsertServiceRequest {
 	return project.UpsertServiceRequest{
 		ProjectUpsertRequest: project.UpsertRepositoryRequest{
-			Name:        toString(p.Name),
-			Description: toStringPointer(p.Description),
+			Name:        ToString(p.Name),
+			Description: ToStringPointer(p.Description),
 		},
 		EnvironmentVariables: p.EnvironmentVariableList().diffRequest(state.EnvironmentVariableList()),
 		Secrets:              p.SecretList().diffRequest(state.SecretList()),
@@ -53,10 +53,10 @@ func (p Project) toUpdateServiceRequest(state Project) project.UpsertServiceRequ
 
 func convertDomainProjectToProject(state Project, res *project.Project) Project {
 	return Project{
-		Id:                          fromString(res.ID.String()),
-		OrganizationId:              fromString(res.OrganizationID.String()),
-		Name:                        fromString(res.Name),
-		Description:                 fromStringPointer(res.Description),
+		Id:                          FromString(res.ID.String()),
+		OrganizationId:              FromString(res.OrganizationID.String()),
+		Name:                        FromString(res.Name),
+		Description:                 FromStringPointer(res.Description),
 		EnvironmentVariables:        convertDomainVariablesToEnvironmentVariableList(res.EnvironmentVariables, variable.ScopeProject).toTerraformSet(),
 		BuiltInEnvironmentVariables: convertDomainVariablesToEnvironmentVariableList(res.BuiltInEnvironmentVariables, variable.ScopeBuiltIn).toTerraformSet(),
 		Secrets:                     convertDomainSecretsToSecretList(state.SecretList(), res.Secrets, variable.ScopeProject).toTerraformSet(),

--- a/qovery/resource_scaleway_credentials_model.go
+++ b/qovery/resource_scaleway_credentials_model.go
@@ -23,18 +23,18 @@ type ScalewayCredentialsDataSource struct {
 
 func (creds ScalewayCredentials) toUpsertScalewayRequest() credentials.UpsertScalewayRequest {
 	return credentials.UpsertScalewayRequest{
-		Name:              toString(creds.Name),
-		ScalewayProjectID: toString(creds.ScalewayProjectId),
-		ScalewayAccessKey: toString(creds.ScalewayAccessKey),
-		ScalewaySecretKey: toString(creds.ScalewaySecretKey),
+		Name:              ToString(creds.Name),
+		ScalewayProjectID: ToString(creds.ScalewayProjectId),
+		ScalewayAccessKey: ToString(creds.ScalewayAccessKey),
+		ScalewaySecretKey: ToString(creds.ScalewaySecretKey),
 	}
 }
 
 func convertDomainCredentialsToScalewayCredentials(creds *credentials.Credentials, plan ScalewayCredentials) ScalewayCredentials {
 	return ScalewayCredentials{
-		Id:                fromString(creds.ID.String()),
-		OrganizationId:    fromString(creds.OrganizationID.String()),
-		Name:              fromString(creds.Name),
+		Id:                FromString(creds.ID.String()),
+		OrganizationId:    FromString(creds.OrganizationID.String()),
+		Name:              FromString(creds.Name),
 		ScalewayProjectId: plan.ScalewayProjectId,
 		ScalewayAccessKey: plan.ScalewayAccessKey,
 		ScalewaySecretKey: plan.ScalewaySecretKey,
@@ -43,8 +43,8 @@ func convertDomainCredentialsToScalewayCredentials(creds *credentials.Credential
 
 func convertDomainCredentialsToScalewayCredentialsDataSource(creds *credentials.Credentials) ScalewayCredentialsDataSource {
 	return ScalewayCredentialsDataSource{
-		Id:             fromString(creds.ID.String()),
-		OrganizationId: fromString(creds.OrganizationID.String()),
-		Name:           fromString(creds.Name),
+		Id:             FromString(creds.ID.String()),
+		OrganizationId: FromString(creds.OrganizationID.String()),
+		Name:           FromString(creds.Name),
 	}
 }

--- a/qovery/secret_model.go
+++ b/qovery/secret_model.go
@@ -48,7 +48,7 @@ func (ss SecretList) contains(e Secret) bool {
 
 func (ss SecretList) find(key string) *Secret {
 	for _, v := range ss {
-		if toString(v.Key) == key {
+		if ToString(v.Key) == key {
 			return &v
 		}
 	}
@@ -63,7 +63,7 @@ func (ss SecretList) diff(old SecretList) client.SecretsDiff {
 	}
 
 	for _, s := range old {
-		if updatedVar := ss.find(toString(s.Key)); updatedVar != nil {
+		if updatedVar := ss.find(ToString(s.Key)); updatedVar != nil {
 			if updatedVar.Value != s.Value {
 				diff.Update = append(diff.Update, s.toUpdateRequest(*updatedVar))
 			}
@@ -89,7 +89,7 @@ func (ss SecretList) diffRequest(old SecretList) secret.DiffRequest {
 	}
 
 	for _, s := range old {
-		if updatedVar := ss.find(toString(s.Key)); updatedVar != nil {
+		if updatedVar := ss.find(ToString(s.Key)); updatedVar != nil {
 			if updatedVar.Value != s.Value {
 				diff.Update = append(diff.Update, s.toDiffUpdateRequest(*updatedVar))
 			}
@@ -127,8 +127,8 @@ func (s Secret) toTerraformObject() types.Object {
 func (s Secret) toCreateRequest() client.SecretCreateRequest {
 	return client.SecretCreateRequest{
 		SecretRequest: qovery.SecretRequest{
-			Key:   toString(s.Key),
-			Value: toString(s.Value),
+			Key:   ToString(s.Key),
+			Value: ToString(s.Value),
 		},
 	}
 }
@@ -136,48 +136,48 @@ func (s Secret) toCreateRequest() client.SecretCreateRequest {
 func (s Secret) toDiffCreateRequest() secret.DiffCreateRequest {
 	return secret.DiffCreateRequest{
 		UpsertRequest: secret.UpsertRequest{
-			Key:   toString(s.Key),
-			Value: toString(s.Value),
+			Key:   ToString(s.Key),
+			Value: ToString(s.Value),
 		},
 	}
 }
 
 func (s Secret) toUpdateRequest(new Secret) client.SecretUpdateRequest {
 	return client.SecretUpdateRequest{
-		Id: toString(s.Id),
+		Id: ToString(s.Id),
 		SecretEditRequest: qovery.SecretEditRequest{
-			Key:   toString(s.Key),
-			Value: toString(new.Value),
+			Key:   ToString(s.Key),
+			Value: ToString(new.Value),
 		},
 	}
 }
 
 func (s Secret) toDiffUpdateRequest(new Secret) secret.DiffUpdateRequest {
 	return secret.DiffUpdateRequest{
-		SecretID: toString(s.Id),
+		SecretID: ToString(s.Id),
 		UpsertRequest: secret.UpsertRequest{
-			Key:   toString(s.Key),
-			Value: toString(new.Value),
+			Key:   ToString(s.Key),
+			Value: ToString(new.Value),
 		},
 	}
 }
 
 func (s Secret) toDeleteRequest() client.SecretDeleteRequest {
 	return client.SecretDeleteRequest{
-		Id: toString(s.Id),
+		Id: ToString(s.Id),
 	}
 }
 
 func (s Secret) toDiffDeleteRequest() secret.DiffDeleteRequest {
 	return secret.DiffDeleteRequest{
-		SecretID: toString(s.Id),
+		SecretID: ToString(s.Id),
 	}
 }
 
 func fromSecret(v *qovery.Secret, state *Secret) Secret {
 	sec := Secret{
-		Id:  fromString(v.Id),
-		Key: fromString(v.Key),
+		Id:  FromString(v.Id),
+		Key: FromString(v.Key),
 	}
 	if state != nil {
 		sec.Value = state.Value
@@ -188,7 +188,7 @@ func fromSecret(v *qovery.Secret, state *Secret) Secret {
 func fromSecretList(state SecretList, secrets []*qovery.Secret, scope qovery.APIVariableScopeEnum) SecretList {
 	stateByKey := make(map[string]Secret)
 	for _, s := range state {
-		stateByKey[toString(s.Key)] = s
+		stateByKey[ToString(s.Key)] = s
 	}
 
 	list := make([]Secret, 0, len(secrets))
@@ -208,7 +208,7 @@ func fromSecretList(state SecretList, secrets []*qovery.Secret, scope qovery.API
 func convertDomainSecretsToSecretList(state SecretList, secrets secret.Secrets, scope variable.Scope) SecretList {
 	stateByKey := make(map[string]Secret)
 	for _, s := range state {
-		stateByKey[toString(s.Key)] = s
+		stateByKey[ToString(s.Key)] = s
 	}
 
 	list := make([]Secret, 0, len(secrets))
@@ -227,8 +227,8 @@ func convertDomainSecretsToSecretList(state SecretList, secrets secret.Secrets, 
 
 func convertDomainSecretToSecret(s secret.Secret, state *Secret) Secret {
 	sec := Secret{
-		Id:  fromString(s.ID.String()),
-		Key: fromString(s.Key),
+		Id:  FromString(s.ID.String()),
+		Key: FromString(s.Key),
 	}
 	if state != nil {
 		sec.Value = state.Value

--- a/qovery/storage_model.go
+++ b/qovery/storage_model.go
@@ -56,19 +56,19 @@ func (p Storage) toTerraformObject() types.Object {
 
 func (p Storage) toUpsertRequest() storage.UpsertRequest {
 	return storage.UpsertRequest{
-		ID:         toStringPointer(p.ID),
-		Type:       toString(p.Type),
-		MountPoint: toString(p.MountPoint),
-		Size:       toInt32(p.Size),
+		ID:         ToStringPointer(p.ID),
+		Type:       ToString(p.Type),
+		MountPoint: ToString(p.MountPoint),
+		Size:       ToInt32(p.Size),
 	}
 }
 
 func fromStorage(p storage.Storage) Storage {
 	return Storage{
-		ID:         fromString(p.ID.String()),
-		Type:       fromString(p.Type.String()),
-		MountPoint: fromString(p.MountPoint),
-		Size:       fromInt32(p.Size),
+		ID:         FromString(p.ID.String()),
+		Type:       FromString(p.Type.String()),
+		MountPoint: FromString(p.MountPoint),
+		Size:       FromInt32(p.Size),
 	}
 }
 
@@ -98,10 +98,10 @@ func convertDomainStoragesToStorageList(storages storage.Storages) StorageList {
 
 func convertDomainStorageToStorage(s storage.Storage) Storage {
 	return Storage{
-		ID:         fromString(s.ID.String()),
-		Type:       fromString(s.Type.String()),
-		MountPoint: fromString(s.MountPoint),
-		Size:       fromInt32(s.Size),
+		ID:         FromString(s.ID.String()),
+		Type:       FromString(s.Type.String()),
+		MountPoint: FromString(s.MountPoint),
+		Size:       FromInt32(s.Size),
 	}
 }
 

--- a/qovery/types_conversions.go
+++ b/qovery/types_conversions.go
@@ -47,6 +47,7 @@ type ClientEnum interface {
 }
 
 func clientEnumToStringArray[T ClientEnum](enum []T) []string {
+
 	arr := make([]string, len(enum))
 	for idx, e := range enum {
 		arr[idx] = fmt.Sprintf("%s", e)
@@ -55,7 +56,7 @@ func clientEnumToStringArray[T ClientEnum](enum []T) []string {
 }
 
 func fromClientEnum[T ClientEnum](v T) types.String {
-	return fromString(string(v))
+	return FromString(string(v))
 }
 
 func fromClientEnumPointer[T ClientEnum](v *T) types.String {
@@ -69,7 +70,7 @@ func fromClientEnumPointer[T ClientEnum](v *T) types.String {
 // Convert to pointer
 //
 
-func stringAsPointer(v string) *string {
+func StringAsPointer(v string) *string {
 	return &v
 }
 
@@ -77,7 +78,7 @@ func stringAsPointer(v string) *string {
 // Convert Terraform types to Go types
 //
 
-func toNullableNullableBuildPackLanguageEnum(v types.String) qovery.NullableBuildPackLanguageEnum {
+func ToNullableNullableBuildPackLanguageEnum(v types.String) qovery.NullableBuildPackLanguageEnum {
 	enum, err := qovery.NewBuildPackLanguageEnumFromValue(v.Value)
 	if err != nil || v.Null || v.Unknown {
 		s := qovery.NewNullableBuildPackLanguageEnum(nil)
@@ -87,7 +88,7 @@ func toNullableNullableBuildPackLanguageEnum(v types.String) qovery.NullableBuil
 	return *s
 }
 
-func toNullableString(v types.String) qovery.NullableString {
+func ToNullableString(v types.String) qovery.NullableString {
 	if v.Null || v.Unknown {
 		s := qovery.NewNullableString(nil)
 		return *s
@@ -96,33 +97,33 @@ func toNullableString(v types.String) qovery.NullableString {
 	return *s
 }
 
-func toString(v types.String) string {
+func ToString(v types.String) string {
 	return v.Value
 }
 
-func toStringPointer(v types.String) *string {
+func ToStringPointer(v types.String) *string {
 	if v.Null || v.Unknown {
 		return nil
 	}
 	return &v.Value
 }
 
-func toBool(v types.Bool) bool {
+func ToBool(v types.Bool) bool {
 	return v.Value
 }
 
-func toBoolPointer(v types.Bool) *bool {
+func ToBoolPointer(v types.Bool) *bool {
 	if v.Null || v.Unknown {
 		return nil
 	}
 	return &v.Value
 }
 
-func toInt32(v types.Int64) int32 {
+func ToInt32(v types.Int64) int32 {
 	return int32(v.Value)
 }
 
-func toInt32Pointer(v types.Int64) *int32 {
+func ToInt32Pointer(v types.Int64) *int32 {
 	if v.Null || v.Unknown {
 		return nil
 	}
@@ -130,7 +131,7 @@ func toInt32Pointer(v types.Int64) *int32 {
 	return &i
 }
 
-func toUInt32Pointer(v types.Int64) *uint32 {
+func ToUInt32Pointer(v types.Int64) *uint32 {
 	if v.Null || v.Unknown {
 		return nil
 	}
@@ -138,11 +139,11 @@ func toUInt32Pointer(v types.Int64) *uint32 {
 	return &i
 }
 
-func toInt64(v types.Int64) int32 {
+func ToInt64(v types.Int64) int32 {
 	return int32(v.Value)
 }
 
-func toInt64Pointer(v types.Int64) *int32 {
+func ToInt64Pointer(v types.Int64) *int32 {
 	if v.Null || v.Unknown {
 		return nil
 	}
@@ -150,10 +151,10 @@ func toInt64Pointer(v types.Int64) *int32 {
 	return &i
 }
 
-func toMapStringString(obj types.Object) (map[string]interface{}, error) {
+func ToMapStringString(obj types.Object) (map[string]interface{}, error) {
 	ret := make(map[string]interface{}, len(obj.Attrs))
 	for k, v := range obj.Attrs {
-		value, err := fromTfValueToGoValue(v)
+		value, err := FromTfValueToGoValue(v)
 		if err != nil {
 			return nil, err
 		}
@@ -162,14 +163,14 @@ func toMapStringString(obj types.Object) (map[string]interface{}, error) {
 	return ret, nil
 }
 
-func toStringArray(set types.List) []string {
+func ToStringArray(set types.List) []string {
 	if set.Null || set.Unknown {
 		return []string{}
 	}
 
 	array := make([]string, 0, len(set.Elems))
 	for _, elem := range set.Elems {
-		array = append(array, toString(elem.(types.String)))
+		array = append(array, ToString(elem.(types.String)))
 	}
 
 	return array
@@ -179,66 +180,66 @@ func toStringArray(set types.List) []string {
 // Convert Go types to Terraform types
 //
 
-func fromNullableNullableBuildPackLanguageEnum(v qovery.NullableBuildPackLanguageEnum) types.String {
+func FromNullableNullableBuildPackLanguageEnum(v qovery.NullableBuildPackLanguageEnum) types.String {
 	if v.Get() == nil {
-		return fromStringPointer(nil)
+		return FromStringPointer(nil)
 	}
-	return fromString(string(*v.Get()))
+	return FromString(string(*v.Get()))
 }
 
-func fromString(v string) types.String {
+func FromString(v string) types.String {
 	return types.String{Value: v}
 }
 
-func fromStringPointer(v *string) types.String {
+func FromStringPointer(v *string) types.String {
 	if v == nil {
 		return types.String{Null: true}
 	}
-	return fromString(*v)
+	return FromString(*v)
 }
 
-func fromNullableString(v qovery.NullableString) types.String {
+func FromNullableString(v qovery.NullableString) types.String {
 	if v.Get() == nil {
 		return types.String{Null: true}
 	}
-	return fromString(*v.Get())
+	return FromString(*v.Get())
 }
 
-func fromInt64(v int64) types.Int64 {
+func FromInt64(v int64) types.Int64 {
 	return types.Int64{Value: v}
 }
 
-func fromUInt64(v uint64) types.Int64 {
+func FromUInt64(v uint64) types.Int64 {
 	return types.Int64{Value: int64(v)}
 }
 
-func fromInt32(v int32) types.Int64 {
-	return fromInt64(int64(v))
+func FromInt32(v int32) types.Int64 {
+	return FromInt64(int64(v))
 }
 
-func fromUInt32(v uint32) types.Int64 {
-	return fromUInt64(uint64(v))
+func FromUInt32(v uint32) types.Int64 {
+	return FromUInt64(uint64(v))
 }
 
-func fromInt32Pointer(v *int32) types.Int64 {
+func FromInt32Pointer(v *int32) types.Int64 {
 	if v == nil {
 		return types.Int64{Null: true}
 	}
-	return fromInt32(*v)
+	return FromInt32(*v)
 }
 
-func fromBool(v bool) types.Bool {
+func FromBool(v bool) types.Bool {
 	return types.Bool{Value: v}
 }
 
-func fromBoolPointer(v *bool) types.Bool {
+func FromBoolPointer(v *bool) types.Bool {
 	if v == nil {
 		return types.Bool{Null: true}
 	}
-	return fromBool(*v)
+	return FromBool(*v)
 }
 
-func fromStringArray(array []string) types.List {
+func FromStringArray(array []string) types.List {
 	set := types.List{
 		ElemType: types.StringType,
 	}
@@ -250,12 +251,12 @@ func fromStringArray(array []string) types.List {
 
 	set.Elems = make([]attr.Value, 0, len(array))
 	for _, v := range array {
-		set.Elems = append(set.Elems, fromString(v))
+		set.Elems = append(set.Elems, FromString(v))
 	}
 	return set
 }
 
-func fromGoValueToTfValue(value interface{}, _type attr.Type) (attr.Value, error) {
+func FromGoValueToTfValue(value interface{}, _type attr.Type) (attr.Value, error) {
 	switch _type {
 	case types.StringType:
 		return types.String{Value: value.(string)}, nil
@@ -280,7 +281,7 @@ func fromGoValueToTfValue(value interface{}, _type attr.Type) (attr.Value, error
 	return types.Object{Null: true}, fmt.Errorf("unable to parse %s as %s", value, _type.String())
 }
 
-func fromTfValueToGoValue(v attr.Value) (interface{}, error) {
+func FromTfValueToGoValue(v attr.Value) (interface{}, error) {
 	switch v.Type(context.Background()) {
 	case types.StringType:
 		value := strings.Trim(v.String(), "\"")
@@ -304,7 +305,7 @@ func fromTfValueToGoValue(v attr.Value) (interface{}, error) {
 	return nil, fmt.Errorf("unable to parse %s as Go value", v.String())
 }
 
-func fromStringMap(value *map[string]interface{}) types.Object {
+func FromStringMap(value *map[string]interface{}) types.Object {
 	if value == nil || len(*value) == 0 {
 		return types.Object{Null: true}
 	}
@@ -316,7 +317,7 @@ func fromStringMap(value *map[string]interface{}) types.Object {
 	}
 
 	for k, f := range *value {
-		attribute, err := fromGoValueToTfValue(f, attrTypes[k])
+		attribute, err := FromGoValueToTfValue(f, attrTypes[k])
 
 		if err != nil {
 			tflog.Warn(context.Background(), "Unable to parse attribute, using default value.", map[string]interface{}{"error": err.Error()})


### PR DESCRIPTION
This CL introduces a better way to generate acceptance tests for
resources job, allowing to craft a plain job truct instead to have to do
wild string concat for each resources tests and hence one aggregation
function.
