### PR TITLE
Revert "chore: bump qovery client version (#367)"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.29.0
 	github.com/pkg/errors v0.9.1
-	github.com/qovery/qovery-client-go v0.0.0-20240429133024-1958d762dc85
+	github.com/qovery/qovery-client-go v0.0.0-20240422162248-1a51e133ad7d
 	github.com/schollz/progressbar/v3 v3.13.0
 	github.com/sethvargo/go-envconfig v0.9.0
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -407,8 +407,6 @@ github.com/qovery/qovery-client-go v0.0.0-20240215160333-8424923c00e9 h1:kbN+bPG
 github.com/qovery/qovery-client-go v0.0.0-20240215160333-8424923c00e9/go.mod h1:5QD7sC1Z6XCCYd31c4XKVwGdEOjvtgG0NDcaVDoWb+o=
 github.com/qovery/qovery-client-go v0.0.0-20240422162248-1a51e133ad7d h1:5BV09IY06+bhqVcXuFwJjjBUKc1wSYA/LyoGxcgw6js=
 github.com/qovery/qovery-client-go v0.0.0-20240422162248-1a51e133ad7d/go.mod h1:9eHj5a4EtXGIyfbvVL3HVYW9k7Xmiwi00OqHrP4dc10=
-github.com/qovery/qovery-client-go v0.0.0-20240429133024-1958d762dc85 h1:6XMOJ6hGbvhDOq8MTBJ4LHsLRKoLZstuemDDVyW4EMg=
-github.com/qovery/qovery-client-go v0.0.0-20240429133024-1958d762dc85/go.mod h1:9eHj5a4EtXGIyfbvVL3HVYW9k7Xmiwi00OqHrP4dc10=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.3 h1:utMvzDsuh3suAEnhH0RdHmoPbU648o6CvXxTx4SBMOw=
 github.com/rivo/uniseg v0.4.3/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=


### PR DESCRIPTION
This reverts commit 5344262b88962b21443b949401a3d9d34d0cb776.