### PR TITLE
feat: add dockerfile_fragment support to terraform service

### DIFF
--- a/docs/resources/terraform_service.md
+++ b/docs/resources/terraform_service.md
@@ -75,6 +75,20 @@ resource "qovery_terraform_service" "my_terraform_service" {
   #   destroy = ["-auto-approve"]
   # }
 
+  # Optional: Custom Dockerfile fragment to install additional tools
+  # Use file-based for fragments stored in the Git repository:
+  # dockerfile_fragment = {
+  #   file = {
+  #     path = "/custom-build.dockerfile"
+  #   }
+  # }
+  # OR inline for fragments defined directly:
+  # dockerfile_fragment = {
+  #   inline = {
+  #     content = "RUN apt-get update && apt-get install -y --no-install-recommends awscli && rm -rf /var/lib/apt/lists/*"
+  #   }
+  # }
+
   # Optional: Advanced settings
   advanced_settings_json = jsonencode({
     # Non-exhaustive list, the complete list is available in Qovery API doc
@@ -109,6 +123,7 @@ resource "qovery_terraform_service" "my_terraform_service" {
 - `action_extra_arguments` (Map of List of String) Extra CLI arguments for specific Terraform actions (plan, apply, destroy).
 - `advanced_settings_json` (String) Advanced settings in JSON format.
 - `description` (String) Description of the terraform service.
+- `dockerfile_fragment` (Attributes) Custom Dockerfile commands to inject during build. Use this to install additional tools or binaries needed by your Terraform configuration. Exactly one of 'file' or 'inline' must be specified. (see [below for nested schema](#nestedatt--dockerfile_fragment))
 - `icon_uri` (String) Icon URI representing the terraform service.
 - `timeout_seconds` (Number) Timeout in seconds for Terraform operations.
 	- Must be: `>= 0`.
@@ -137,6 +152,29 @@ Optional:
 <a id="nestedatt--backend--user_provided"></a>
 ### Nested Schema for `backend.user_provided`
 
+
+
+<a id="nestedatt--dockerfile_fragment"></a>
+### Nested Schema for `dockerfile_fragment`
+
+Optional:
+
+- `file` (Attributes) Reference to a Dockerfile fragment file in the Git repository. (see [below for nested schema](#nestedatt--dockerfile_fragment--file))
+- `inline` (Attributes) Inline Dockerfile commands to inject. (see [below for nested schema](#nestedatt--dockerfile_fragment--inline))
+
+<a id="nestedatt--dockerfile_fragment--file"></a>
+### Nested Schema for `dockerfile_fragment.file`
+
+Required:
+
+- `path` (String) Absolute path to the Dockerfile fragment file within the repository (must start with /).
+
+<a id="nestedatt--dockerfile_fragment--inline"></a>
+### Nested Schema for `dockerfile_fragment.inline`
+
+Required:
+
+- `content` (String) Dockerfile commands to inject (e.g., RUN, COPY, ADD).
 
 
 <a id="nestedatt--engine_version"></a>

--- a/docs/resources/terraform_service.md
+++ b/docs/resources/terraform_service.md
@@ -75,20 +75,6 @@ resource "qovery_terraform_service" "my_terraform_service" {
   #   destroy = ["-auto-approve"]
   # }
 
-  # Optional: Custom Dockerfile fragment to install additional tools
-  # Use file-based for fragments stored in the Git repository:
-  # dockerfile_fragment = {
-  #   file = {
-  #     path = "/custom-build.dockerfile"
-  #   }
-  # }
-  # OR inline for fragments defined directly:
-  # dockerfile_fragment = {
-  #   inline = {
-  #     content = "RUN apt-get update && apt-get install -y --no-install-recommends awscli && rm -rf /var/lib/apt/lists/*"
-  #   }
-  # }
-
   # Optional: Advanced settings
   advanced_settings_json = jsonencode({
     # Non-exhaustive list, the complete list is available in Qovery API doc
@@ -154,29 +140,6 @@ Optional:
 
 
 
-<a id="nestedatt--dockerfile_fragment"></a>
-### Nested Schema for `dockerfile_fragment`
-
-Optional:
-
-- `file` (Attributes) Reference to a Dockerfile fragment file in the Git repository. (see [below for nested schema](#nestedatt--dockerfile_fragment--file))
-- `inline` (Attributes) Inline Dockerfile commands to inject. (see [below for nested schema](#nestedatt--dockerfile_fragment--inline))
-
-<a id="nestedatt--dockerfile_fragment--file"></a>
-### Nested Schema for `dockerfile_fragment.file`
-
-Required:
-
-- `path` (String) Absolute path to the Dockerfile fragment file within the repository (must start with /).
-
-<a id="nestedatt--dockerfile_fragment--inline"></a>
-### Nested Schema for `dockerfile_fragment.inline`
-
-Required:
-
-- `content` (String) Dockerfile commands to inject (e.g., RUN, COPY, ADD).
-
-
 <a id="nestedatt--engine_version"></a>
 ### Nested Schema for `engine_version`
 
@@ -220,6 +183,31 @@ Optional:
 - `storage_gib` (Number) Storage of the terraform job in GiB [1 GiB = 1024 MiB]. WARNING: Cannot be reduced after creation.
 	- Must be: `>= 1`.
 	- Default: `20`.
+
+
+<a id="nestedatt--dockerfile_fragment"></a>
+### Nested Schema for `dockerfile_fragment`
+
+Optional:
+
+- `file` (Attributes) Reference to a Dockerfile fragment file in the Git repository. (see [below for nested schema](#nestedatt--dockerfile_fragment--file))
+- `inline` (Attributes) Inline Dockerfile commands to inject. (see [below for nested schema](#nestedatt--dockerfile_fragment--inline))
+
+<a id="nestedatt--dockerfile_fragment--file"></a>
+### Nested Schema for `dockerfile_fragment.file`
+
+Required:
+
+- `path` (String) Absolute path to the Dockerfile fragment file within the repository (must start with /).
+
+
+<a id="nestedatt--dockerfile_fragment--inline"></a>
+### Nested Schema for `dockerfile_fragment.inline`
+
+Required:
+
+- `content` (String) Dockerfile commands to inject (e.g., RUN, COPY, ADD). Maximum 64KB.
+
 
 
 <a id="nestedatt--variables"></a>

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
 	github.com/pkg/errors v0.9.1
-	github.com/qovery/qovery-client-go v0.0.0-20251212101551-87c41622797f
+	github.com/qovery/qovery-client-go v0.0.0-20251217100241-392627185009
 	github.com/schollz/progressbar/v3 v3.18.0
 	github.com/sethvargo/go-envconfig v1.1.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -193,8 +193,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
-github.com/qovery/qovery-client-go v0.0.0-20251212101551-87c41622797f h1:gY731hViYd2cVWCvqVdmtq7tvaLU6W24d1MRK+zvMb4=
-github.com/qovery/qovery-client-go v0.0.0-20251212101551-87c41622797f/go.mod h1:mcXeQtxR4AIGIBaWLhy52S16UwL8/1fcDywDuSK1BZ4=
+github.com/qovery/qovery-client-go v0.0.0-20251217100241-392627185009 h1:mXjobGh7Js9oxXIbbdU3nHSuGhYs3bFB3d0S4ibUqJI=
+github.com/qovery/qovery-client-go v0.0.0-20251217100241-392627185009/go.mod h1:mcXeQtxR4AIGIBaWLhy52S16UwL8/1fcDywDuSK1BZ4=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/internal/domain/terraformservice/terraformservice_repository.go
+++ b/internal/domain/terraformservice/terraformservice_repository.go
@@ -33,6 +33,7 @@ type UpsertRepositoryRequest struct {
 	TimeoutSec            *int32
 	IconURI               string
 	UseClusterCredentials bool
+	DockerfileFragment    *DockerfileFragment
 	ActionExtraArguments  map[string][]string
 	AdvancedSettingsJson  string
 }
@@ -82,6 +83,13 @@ func (r UpsertRepositoryRequest) Validate() error {
 			errors.New("timeout_sec must be at least 0"),
 			ErrInvalidTerraformServiceUpsertRequest.Error(),
 		)
+	}
+
+	// Validate dockerfile fragment (optional)
+	if r.DockerfileFragment != nil {
+		if err := r.DockerfileFragment.Validate(); err != nil {
+			return errors.Wrap(err, ErrInvalidTerraformServiceUpsertRequest.Error())
+		}
 	}
 
 	if err := validator.New().Struct(r); err != nil {

--- a/qovery/resource_terraform_service.go
+++ b/qovery/resource_terraform_service.go
@@ -259,6 +259,32 @@ func (r terraformServiceResource) Schema(_ context.Context, _ resource.SchemaReq
 				Computed:    true,
 				Default:     booldefault.StaticBool(false),
 			},
+			"dockerfile_fragment": schema.SingleNestedAttribute{
+				Description: "Custom Dockerfile commands to inject during build. Use this to install additional tools or binaries needed by your Terraform configuration. Exactly one of 'file' or 'inline' must be specified.",
+				Optional:    true,
+				Attributes: map[string]schema.Attribute{
+					"file": schema.SingleNestedAttribute{
+						Description: "Reference to a Dockerfile fragment file in the Git repository.",
+						Optional:    true,
+						Attributes: map[string]schema.Attribute{
+							"path": schema.StringAttribute{
+								Description: "Absolute path to the Dockerfile fragment file within the repository (must start with /).",
+								Required:    true,
+							},
+						},
+					},
+					"inline": schema.SingleNestedAttribute{
+						Description: "Inline Dockerfile commands to inject.",
+						Optional:    true,
+						Attributes: map[string]schema.Attribute{
+							"content": schema.StringAttribute{
+								Description: "Dockerfile commands to inject (e.g., RUN, COPY, ADD). Maximum 64KB.",
+								Required:    true,
+							},
+						},
+					},
+				},
+			},
 			"action_extra_arguments": schema.MapAttribute{
 				Description: "Extra CLI arguments for specific Terraform actions (plan, apply, destroy).",
 				Optional:    true,


### PR DESCRIPTION
Add custom Dockerfile fragment capability to terraform services, allowing users to:
- Reference Dockerfile fragments from files in the Git repository
- Define inline Dockerfile commands directly in the configuration

This enables installing additional tools or binaries needed by Terraform configurations.