### PR TITLE
fix: prevent false environment_id replacement when upstream resources have pending changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,4 @@ terraform.rc
 terraform
 
 # Ignore test output json file
-test-output.json
+test-output.json.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ terraform
 
 # Ignore test output json file
 test-output.json.worktrees/
+test-output.json

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -47,7 +47,7 @@ tasks:
     deps:
       - install-gotestsum
     cmds:
-      - gotestsum --format testname --jsonfile test-output.json --rerun-fails=2 --packages="./..." -- -tags=unit -cover -timeout 2h -parallel 4
+      - gotestsum --format testname --jsonfile test-output.json --rerun-fails=2 --packages="./..." -- -tags=unit -cover -timeout 2h -parallel 4 {{.CLI_ARGS}}
 
   testacc:
     desc: Run acceptance tests
@@ -56,7 +56,7 @@ tasks:
     env:
       TF_ACC: true
     cmds:
-      - gotestsum --format testname --jsonfile test-output.json --rerun-fails=2 --packages="./..." -- -tags=integration -cover -timeout 2h -parallel 3
+      - gotestsum --format testname --jsonfile test-output.json --rerun-fails=2 --packages="./..." -- -tags=integration -cover -timeout 2h -parallel 3 {{.CLI_ARGS}}
 
   docs:
     desc: Update the generated documentation

--- a/docs/resources/helm.md
+++ b/docs/resources/helm.md
@@ -163,7 +163,7 @@ resource "qovery_helm" "my_helm_from_git" {
 
 - `allow_cluster_wide_resources` (Boolean) Allow this chart to deploy resources outside of this environment namespace (including CRDs or non-namespaced resources)
 - `description` (String) Description of the helm service.
-- `environment_id` (String) Id of the environment.
+- `environment_id` (String) Id of the environment. Changing this forces the helm service to be re-created.
 - `name` (String) Name of the helm service.
 - `source` (Attributes) Helm chart source. Use `helm_repository` to deploy from a Helm repository, or `git_repository` to deploy from a git repository. (see [below for nested schema](#nestedatt--source))
 - `values_override` (Attributes) Define your own overrides to customize the helm chart behaviour. (see [below for nested schema](#nestedatt--values_override))

--- a/docs/resources/job.md
+++ b/docs/resources/job.md
@@ -163,7 +163,7 @@ You can find complete examples within these repositories:
 
 ### Required
 
-- `environment_id` (String) Id of the environment.
+- `environment_id` (String) Id of the environment. Changing this forces the job to be re-created.
 - `healthchecks` (Attributes) Configuration for the healthchecks that are going to be executed against your service. At least one of `readiness_probe` or `liveness_probe` should be configured for production workloads. (see [below for nested schema](#nestedatt--healthchecks))
 - `name` (String) Name of the job.
 - `schedule` (Attributes) Job's schedule configuration. Use `on_start`, `on_stop`, and `on_delete` for lifecycle jobs, or `cronjob` for cron jobs. (see [below for nested schema](#nestedatt--schedule))

--- a/docs/resources/terraform_service.md
+++ b/docs/resources/terraform_service.md
@@ -101,7 +101,7 @@ resource "qovery_terraform_service" "my_terraform_service" {
 - `backend` (Attributes) Terraform backend configuration. Exactly one backend type must be specified. (see [below for nested schema](#nestedatt--backend))
 - `engine` (String) Terraform engine to use (TERRAFORM or OPEN_TOFU).
 - `engine_version` (Attributes) Terraform/OpenTofu engine version configuration. (see [below for nested schema](#nestedatt--engine_version))
-- `environment_id` (String) Id of the environment.
+- `environment_id` (String) Id of the environment. Changing this forces the terraform service to be re-created.
 - `git_repository` (Attributes) Terraform service git repository configuration. (see [below for nested schema](#nestedatt--git_repository))
 - `job_resources` (Attributes) Resource allocation for the Terraform job. (see [below for nested schema](#nestedatt--job_resources))
 - `name` (String) Name of the terraform service.

--- a/qovery/environment_id_replacement_test.go
+++ b/qovery/environment_id_replacement_test.go
@@ -1,0 +1,347 @@
+//go:build unit && !integration
+// +build unit,!integration
+
+// Tests for RequiresReplaceIfKnownChange and its application to RequiresReplace
+// ID attributes (environment_id, cluster_id) in resource schemas.
+package qovery
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
+)
+
+// testSchemaEnvironmentID is a minimal schema with one string attribute used for
+// constructing synthetic State/Plan/Config trees in the tests below.
+var testSchemaEnvironmentID = schema.Schema{
+	Attributes: map[string]schema.Attribute{
+		"environment_id": schema.StringAttribute{},
+	},
+}
+
+// buildState returns a tfsdk.State whose Raw is non-null and carries the given value
+// for the `environment_id` attribute. Pass a null types.String to mark the attribute
+// itself null; pass nil to mark the whole state null (resource being created).
+func buildState(value *types.String) tfsdk.State {
+	ctx := context.Background()
+	objType := testSchemaEnvironmentID.Type().TerraformType(ctx)
+
+	if value == nil {
+		return tfsdk.State{
+			Schema: testSchemaEnvironmentID,
+			Raw:    tftypes.NewValue(objType, nil),
+		}
+	}
+
+	tfValue, err := value.ToTerraformValue(ctx)
+	if err != nil {
+		panic("ToTerraformValue: " + err.Error())
+	}
+	return tfsdk.State{
+		Schema: testSchemaEnvironmentID,
+		Raw: tftypes.NewValue(objType, map[string]tftypes.Value{
+			"environment_id": tfValue,
+		}),
+	}
+}
+
+func buildPlan(value *types.String) tfsdk.Plan {
+	ctx := context.Background()
+	objType := testSchemaEnvironmentID.Type().TerraformType(ctx)
+
+	if value == nil {
+		return tfsdk.Plan{
+			Schema: testSchemaEnvironmentID,
+			Raw:    tftypes.NewValue(objType, nil),
+		}
+	}
+
+	tfValue, err := value.ToTerraformValue(ctx)
+	if err != nil {
+		panic("ToTerraformValue: " + err.Error())
+	}
+	return tfsdk.Plan{
+		Schema: testSchemaEnvironmentID,
+		Raw: tftypes.NewValue(objType, map[string]tftypes.Value{
+			"environment_id": tfValue,
+		}),
+	}
+}
+
+func buildConfig(value *types.String) tfsdk.Config {
+	ctx := context.Background()
+	objType := testSchemaEnvironmentID.Type().TerraformType(ctx)
+
+	if value == nil {
+		return tfsdk.Config{
+			Schema: testSchemaEnvironmentID,
+			Raw:    tftypes.NewValue(objType, nil),
+		}
+	}
+
+	tfValue, err := value.ToTerraformValue(ctx)
+	if err != nil {
+		panic("ToTerraformValue: " + err.Error())
+	}
+	return tfsdk.Config{
+		Schema: testSchemaEnvironmentID,
+		Raw: tftypes.NewValue(objType, map[string]tftypes.Value{
+			"environment_id": tfValue,
+		}),
+	}
+}
+
+// ptrUnknown returns a pointer to an Unknown string value for use with the build* helpers.
+func ptrUnknown() *types.String {
+	v := types.StringUnknown()
+	return &v
+}
+
+// ----------------------------------------------------------------------------
+// Predicate unit tests — exercise requiresReplaceIfKnownChangeFunc directly,
+// bypassing the framework's RequiresReplaceIf guards.
+// ----------------------------------------------------------------------------
+
+func TestRequiresReplaceIfKnownChangeFunc_PlanKnown_SetsReplace(t *testing.T) {
+	t.Parallel()
+
+	resp := &stringplanmodifier.RequiresReplaceIfFuncResponse{}
+	requiresReplaceIfKnownChangeFunc(context.Background(), planmodifier.StringRequest{
+		PlanValue: types.StringValue("env-uuid-NEW"),
+	}, resp)
+
+	assert.True(t, resp.RequiresReplace,
+		"a known plan value differing from state must require replacement")
+}
+
+func TestRequiresReplaceIfKnownChangeFunc_PlanUnknown_DoesNotSetReplace(t *testing.T) {
+	t.Parallel()
+
+	resp := &stringplanmodifier.RequiresReplaceIfFuncResponse{}
+	requiresReplaceIfKnownChangeFunc(context.Background(), planmodifier.StringRequest{
+		PlanValue: types.StringUnknown(),
+	}, resp)
+
+	assert.False(t, resp.RequiresReplace,
+		"unknown plan value must not require replacement")
+}
+
+// ----------------------------------------------------------------------------
+// Integration tests — exercise the full RequiresReplaceIfKnownChange() modifier
+// through the framework's call path.
+// ----------------------------------------------------------------------------
+
+// TestRequiresReplaceIfKnownChange_UnknownPlan_Integration verifies the modifier
+// when both ConfigValue and PlanValue are unknown (e.g., the config interpolates
+// a deferred data source).
+func TestRequiresReplaceIfKnownChange_UnknownPlan_Integration(t *testing.T) {
+	t.Parallel()
+
+	stateVal := types.StringValue("env-uuid-123")
+	resp := &planmodifier.StringResponse{PlanValue: types.StringUnknown()}
+
+	RequiresReplaceIfKnownChange().PlanModifyString(context.Background(), planmodifier.StringRequest{
+		Config:      buildConfig(ptrUnknown()),
+		ConfigValue: types.StringUnknown(),
+		State:       buildState(&stateVal),
+		StateValue:  stateVal,
+		Plan:        buildPlan(ptrUnknown()),
+		PlanValue:   types.StringUnknown(),
+	}, resp)
+
+	assert.False(t, resp.RequiresReplace,
+		"unknown plan value must not trigger replacement")
+}
+
+// TestRequiresReplaceIfKnownChange_RealChange_Integration verifies that a
+// known-value change to a different value triggers replacement.
+func TestRequiresReplaceIfKnownChange_RealChange_Integration(t *testing.T) {
+	t.Parallel()
+
+	stateVal := types.StringValue("env-uuid-OLD")
+	newVal := types.StringValue("env-uuid-NEW")
+	resp := &planmodifier.StringResponse{PlanValue: newVal}
+
+	RequiresReplaceIfKnownChange().PlanModifyString(context.Background(), planmodifier.StringRequest{
+		Config:      buildConfig(&newVal),
+		ConfigValue: newVal,
+		State:       buildState(&stateVal),
+		StateValue:  stateVal,
+		Plan:        buildPlan(&newVal),
+		PlanValue:   newVal,
+	}, resp)
+
+	assert.True(t, resp.RequiresReplace,
+		"a known-value change must require replacement")
+}
+
+// ----------------------------------------------------------------------------
+// Schema regression tests — verify each known RequiresReplace ID attribute uses
+// RequiresReplaceIfKnownChange().
+// ----------------------------------------------------------------------------
+
+// hasRequiresReplaceIfKnownChange reports whether the modifier slice contains
+// RequiresReplaceIfKnownChange. The framework's modifier types are unexported, so
+// we compare by Description string.
+func hasRequiresReplaceIfKnownChange(mods []planmodifier.String) bool {
+	ctx := context.Background()
+	wantDesc := RequiresReplaceIfKnownChange().Description(ctx)
+	for _, m := range mods {
+		if m.Description(ctx) == wantDesc {
+			return true
+		}
+	}
+	return false
+}
+
+// hasStockRequiresReplace reports whether the modifier slice contains the stock
+// stringplanmodifier.RequiresReplace().
+func hasStockRequiresReplace(mods []planmodifier.String) bool {
+	ctx := context.Background()
+	wantDesc := stringplanmodifier.RequiresReplace().Description(ctx)
+	for _, m := range mods {
+		if m.Description(ctx) == wantDesc {
+			return true
+		}
+	}
+	return false
+}
+
+// vulnerableAttribute pairs a resource schema with the name of a RequiresReplace
+// string attribute that must use RequiresReplaceIfKnownChange().
+type vulnerableAttribute struct {
+	resourceName string
+	attrName     string
+	schema       schema.Schema
+}
+
+func collectVulnerableAttributes(t *testing.T) []vulnerableAttribute {
+	t.Helper()
+
+	schemaOf := func(r interface {
+		Schema(context.Context, resource.SchemaRequest, *resource.SchemaResponse)
+	}) schema.Schema {
+		var resp resource.SchemaResponse
+		r.Schema(context.Background(), resource.SchemaRequest{}, &resp)
+		return resp.Schema
+	}
+
+	return []vulnerableAttribute{
+		{"qovery_container", "environment_id", schemaOf(containerResource{})},
+		{"qovery_helm", "environment_id", schemaOf(helmResource{})},
+		{"qovery_application", "environment_id", schemaOf(applicationResource{})},
+		{"qovery_job", "environment_id", schemaOf(jobResource{})},
+		{"qovery_database", "environment_id", schemaOf(databaseResource{})},
+		{"qovery_terraform_service", "environment_id", schemaOf(terraformServiceResource{})},
+		{"qovery_deployment_stage", "environment_id", schemaOf(deploymentStageResource{})},
+		{"qovery_environment", "cluster_id", schemaOf(environmentResource{})},
+	}
+}
+
+func getPlanModifiers(t *testing.T, s schema.Schema, attrName string) []planmodifier.String {
+	t.Helper()
+	attr, ok := s.Attributes[attrName]
+	if !ok {
+		t.Fatalf("schema missing %q attribute", attrName)
+	}
+	strAttr, ok := attr.(schema.StringAttribute)
+	if !ok {
+		t.Fatalf("%q is not a StringAttribute", attrName)
+	}
+	return strAttr.PlanModifiers
+}
+
+// TestVulnerableAttributes_UseRequiresReplaceIfKnownChange asserts that every
+// listed RequiresReplace ID attribute uses RequiresReplaceIfKnownChange() and not
+// the stock stringplanmodifier.RequiresReplace().
+func TestVulnerableAttributes_UseRequiresReplaceIfKnownChange(t *testing.T) {
+	t.Parallel()
+
+	for _, v := range collectVulnerableAttributes(t) {
+		v := v
+		t.Run(v.resourceName+"."+v.attrName, func(t *testing.T) {
+			t.Parallel()
+			mods := getPlanModifiers(t, v.schema, v.attrName)
+			assert.True(t, hasRequiresReplaceIfKnownChange(mods),
+				"%s.%s must use RequiresReplaceIfKnownChange()", v.resourceName, v.attrName)
+			assert.False(t, hasStockRequiresReplace(mods),
+				"%s.%s must not use stock stringplanmodifier.RequiresReplace()", v.resourceName, v.attrName)
+		})
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Provider-wide reflective scan — walks every resource's schema (including nested
+// attributes) and fails if any StringAttribute uses stock
+// stringplanmodifier.RequiresReplace().
+// ----------------------------------------------------------------------------
+
+// walkStringAttributes invokes fn for every StringAttribute found in the schema
+// attribute tree, recursing into Single/List/Set/Map nested attributes.
+func walkStringAttributes(attrs map[string]schema.Attribute, prefix string, fn func(path string, sa schema.StringAttribute)) {
+	for name, attr := range attrs {
+		full := name
+		if prefix != "" {
+			full = prefix + "." + name
+		}
+		switch a := attr.(type) {
+		case schema.StringAttribute:
+			fn(full, a)
+		case schema.SingleNestedAttribute:
+			walkStringAttributes(a.Attributes, full, fn)
+		case schema.ListNestedAttribute:
+			walkStringAttributes(a.NestedObject.Attributes, full+"[*]", fn)
+		case schema.SetNestedAttribute:
+			walkStringAttributes(a.NestedObject.Attributes, full+"[*]", fn)
+		case schema.MapNestedAttribute:
+			walkStringAttributes(a.NestedObject.Attributes, full+"[*]", fn)
+		}
+	}
+}
+
+// TestProvider_NoStockRequiresReplaceAnywhere walks every resource in the provider
+// and asserts that no StringAttribute uses stock stringplanmodifier.RequiresReplace().
+func TestProvider_NoStockRequiresReplaceAnywhere(t *testing.T) {
+	t.Parallel()
+
+	p := New("test")()
+	ctx := context.Background()
+
+	resourcesProvider, ok := p.(interface {
+		Resources(context.Context) []func() resource.Resource
+	})
+	if !ok {
+		t.Fatalf("provider does not expose Resources(context.Context)")
+	}
+
+	var violations []string
+	for _, factory := range resourcesProvider.Resources(ctx) {
+		res := factory()
+
+		var meta resource.MetadataResponse
+		res.Metadata(ctx, resource.MetadataRequest{ProviderTypeName: "qovery"}, &meta)
+
+		var sresp resource.SchemaResponse
+		res.Schema(ctx, resource.SchemaRequest{}, &sresp)
+
+		walkStringAttributes(sresp.Schema.Attributes, "", func(path string, sa schema.StringAttribute) {
+			if hasStockRequiresReplace(sa.PlanModifiers) {
+				violations = append(violations, meta.TypeName+"."+path)
+			}
+		})
+	}
+
+	if len(violations) > 0 {
+		t.Errorf("the following attributes use stringplanmodifier.RequiresReplace(); replace with RequiresReplaceIfKnownChange() from plan_modifiers.go:\n  - %s",
+			strings.Join(violations, "\n  - "))
+	}
+}

--- a/qovery/plan_modifiers.go
+++ b/qovery/plan_modifiers.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -277,4 +278,28 @@ func attrChanged[T attr.Value](ctx context.Context, req planmodifier.ListRequest
 // the env var values. See useStateUnlessNameChangesModifier for the trigger list.
 func UseStateUnlessNameChanges() planmodifier.List {
 	return useStateUnlessNameChangesModifier{}
+}
+
+// RequiresReplaceIfKnownChange triggers resource replacement only when the planned
+// value is known AND differs from state. When the planned value is unknown,
+// replacement is suppressed.
+//
+// Use this in place of stringplanmodifier.RequiresReplace() on attributes that may
+// be sourced from data sources (e.g. environment_id, cluster_id).
+func RequiresReplaceIfKnownChange() planmodifier.String {
+	return stringplanmodifier.RequiresReplaceIf(
+		requiresReplaceIfKnownChangeFunc,
+		"If the value changes to a different known value, Terraform will destroy and recreate the resource. Replacement is skipped when the planned value is unknown.",
+		"If the value changes to a different known value, Terraform will destroy and recreate the resource. Replacement is **skipped when the planned value is unknown** (e.g., a deferred data source during a `-target` apply).",
+	)
+}
+
+// requiresReplaceIfKnownChangeFunc is the predicate evaluated by
+// RequiresReplaceIfKnownChange after the framework's gates (resource create/destroy,
+// plan==state) have passed.
+func requiresReplaceIfKnownChangeFunc(_ context.Context, req planmodifier.StringRequest, resp *stringplanmodifier.RequiresReplaceIfFuncResponse) {
+	if req.PlanValue.IsUnknown() {
+		return
+	}
+	resp.RequiresReplace = true
 }

--- a/qovery/resource_application.go
+++ b/qovery/resource_application.go
@@ -116,6 +116,7 @@ func (r applicationResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				MarkdownDescription: "Id of the environment. Changing this forces the application to be re-created.",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
 					stringplanmodifier.RequiresReplace(),
 				},
 			},

--- a/qovery/resource_application.go
+++ b/qovery/resource_application.go
@@ -116,8 +116,7 @@ func (r applicationResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				MarkdownDescription: "Id of the environment. Changing this forces the application to be re-created.",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-					stringplanmodifier.RequiresReplace(),
+					RequiresReplaceIfKnownChange(),
 				},
 			},
 			"name": schema.StringAttribute{

--- a/qovery/resource_container.go
+++ b/qovery/resource_container.go
@@ -81,6 +81,7 @@ func (r containerResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				MarkdownDescription: "Id of the environment. Changing this forces the container to be re-created.",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
 					stringplanmodifier.RequiresReplace(),
 				},
 			},

--- a/qovery/resource_container.go
+++ b/qovery/resource_container.go
@@ -81,8 +81,7 @@ func (r containerResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				MarkdownDescription: "Id of the environment. Changing this forces the container to be re-created.",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-					stringplanmodifier.RequiresReplace(),
+					RequiresReplaceIfKnownChange(),
 				},
 			},
 			"registry_id": schema.StringAttribute{

--- a/qovery/resource_container_deferred_env_id_test.go
+++ b/qovery/resource_container_deferred_env_id_test.go
@@ -1,0 +1,109 @@
+//go:build integration && !unit
+
+package qovery_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// TestAcc_Container_DeferredEnvironmentID_NoReplacement reproduces the QOV-1938
+// scenario end-to-end: a container's environment_id flows through a resource
+// whose output is "(known after apply)" at plan time, so the container's planned
+// environment_id is unknown.
+//
+// The wiring uses terraform_data (built-in to Terraform 1.4+). Its `output`
+// attribute equals `input` after apply, but becomes "(known after apply)" when
+// the resource is being replaced (which `triggers_replace` forces).
+//
+// Step 1 creates the container with the wiring in place. Step 2 changes
+// triggers_replace, forcing terraform_data to be replaced, which makes its
+// `output` (and therefore container.environment_id) unknown at plan time. The
+// assertion is that the container's resource ID is unchanged across the two
+// steps — if RequiresReplaceIfKnownChange regresses to stock RequiresReplace,
+// the container is destroyed and recreated and the ID changes.
+func TestAcc_Container_DeferredEnvironmentID_NoReplacement(t *testing.T) {
+	t.Parallel()
+	testName := "container-deferred-env-id"
+	containerName := generateTestName(testName)
+
+	var containerIDStep1 string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccQoveryContainerDestroy("qovery_container.test"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerDeferredEnvIDConfig(testName, containerName, "v1"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccQoveryContainerExists("qovery_container.test"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["qovery_container.test"]
+						if !ok {
+							return fmt.Errorf("qovery_container.test not in state")
+						}
+						containerIDStep1 = rs.Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				Config: testAccContainerDeferredEnvIDConfig(testName, containerName, "v2"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccQoveryContainerExists("qovery_container.test"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["qovery_container.test"]
+						if !ok {
+							return fmt.Errorf("qovery_container.test not in state after step 2")
+						}
+						if rs.Primary.ID != containerIDStep1 {
+							return fmt.Errorf(
+								"container was replaced: ID changed from %s to %s — RequiresReplaceIfKnownChange did not suppress replacement on deferred upstream",
+								containerIDStep1, rs.Primary.ID,
+							)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// testAccContainerDeferredEnvIDConfig wires environment_id through a terraform_data
+// resource whose `output` becomes "(known after apply)" whenever triggers_replace
+// changes. Changing triggerValue between steps forces the resource to be replaced,
+// which makes terraform_data.env_id_holder.output unknown at plan time, which
+// propagates to qovery_container.test.environment_id.
+func testAccContainerDeferredEnvIDConfig(testName, containerName, triggerValue string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "terraform_data" "env_id_holder" {
+  input            = qovery_environment.test.id
+  triggers_replace = ["%s"]
+}
+
+resource "qovery_container" "test" {
+  environment_id = terraform_data.env_id_holder.output
+  registry_id    = qovery_container_registry.test.id
+  name           = "%s"
+  image_name     = "%s"
+  tag            = "%s"
+  healthchecks   = {}
+}
+`,
+		testAccEnvironmentDefaultConfig(testName),
+		testAccContainerRegistryDefaultConfig(testName),
+		triggerValue,
+		containerName,
+		containerImageName,
+		containerTag,
+	)
+}

--- a/qovery/resource_database.go
+++ b/qovery/resource_database.go
@@ -104,6 +104,7 @@ func (r databaseResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				MarkdownDescription: "Id of the environment. Changing this forces the database to be re-created.",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
 					stringplanmodifier.RequiresReplace(),
 				},
 			},

--- a/qovery/resource_database.go
+++ b/qovery/resource_database.go
@@ -104,8 +104,7 @@ func (r databaseResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				MarkdownDescription: "Id of the environment. Changing this forces the database to be re-created.",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-					stringplanmodifier.RequiresReplace(),
+					RequiresReplaceIfKnownChange(),
 				},
 			},
 			"name": schema.StringAttribute{

--- a/qovery/resource_deployment_stage.go
+++ b/qovery/resource_deployment_stage.go
@@ -74,7 +74,7 @@ func (r deploymentStageResource) Schema(_ context.Context, _ resource.SchemaRequ
 				MarkdownDescription: "Identifier of the environment for this deployment stage (UUID format). **Cannot be changed after creation** (forces resource replacement).",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
+					RequiresReplaceIfKnownChange(),
 				},
 			},
 			"name": schema.StringAttribute{

--- a/qovery/resource_environment.go
+++ b/qovery/resource_environment.go
@@ -82,7 +82,7 @@ func (r environmentResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				MarkdownDescription: "Identifier of the cluster where this environment will be deployed (UUID format). **Cannot be changed after creation** (forces resource replacement).",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
+					RequiresReplaceIfKnownChange(),
 				},
 			},
 			"name": schema.StringAttribute{

--- a/qovery/resource_helm.go
+++ b/qovery/resource_helm.go
@@ -79,9 +79,10 @@ func (r helmResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 			},
 			"environment_id": schema.StringAttribute{
 				Description:         "Id of the environment.",
-				MarkdownDescription: "Id of the environment.",
+				MarkdownDescription: "Id of the environment. Changing this forces the helm service to be re-created.",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
 					stringplanmodifier.RequiresReplace(),
 				},
 			},

--- a/qovery/resource_helm.go
+++ b/qovery/resource_helm.go
@@ -82,8 +82,7 @@ func (r helmResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				MarkdownDescription: "Id of the environment. Changing this forces the helm service to be re-created.",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-					stringplanmodifier.RequiresReplace(),
+					RequiresReplaceIfKnownChange(),
 				},
 			},
 			"name": schema.StringAttribute{

--- a/qovery/resource_job.go
+++ b/qovery/resource_job.go
@@ -76,9 +76,10 @@ func (r jobResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *r
 			},
 			"environment_id": schema.StringAttribute{
 				Description:         "Id of the environment.",
-				MarkdownDescription: "Id of the environment.",
+				MarkdownDescription: "Id of the environment. Changing this forces the job to be re-created.",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
 					stringplanmodifier.RequiresReplace(),
 				},
 			},

--- a/qovery/resource_job.go
+++ b/qovery/resource_job.go
@@ -79,8 +79,7 @@ func (r jobResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *r
 				MarkdownDescription: "Id of the environment. Changing this forces the job to be re-created.",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-					stringplanmodifier.RequiresReplace(),
+					RequiresReplaceIfKnownChange(),
 				},
 			},
 			"name": schema.StringAttribute{

--- a/qovery/resource_terraform_service.go
+++ b/qovery/resource_terraform_service.go
@@ -78,9 +78,10 @@ func (r terraformServiceResource) Schema(_ context.Context, _ resource.SchemaReq
 			},
 			"environment_id": schema.StringAttribute{
 				Description:         "Id of the environment.",
-				MarkdownDescription: "Id of the environment.",
+				MarkdownDescription: "Id of the environment. Changing this forces the terraform service to be re-created.",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
 					stringplanmodifier.RequiresReplace(),
 				},
 			},

--- a/qovery/resource_terraform_service.go
+++ b/qovery/resource_terraform_service.go
@@ -81,8 +81,7 @@ func (r terraformServiceResource) Schema(_ context.Context, _ resource.SchemaReq
 				MarkdownDescription: "Id of the environment. Changing this forces the terraform service to be re-created.",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-					stringplanmodifier.RequiresReplace(),
+					RequiresReplaceIfKnownChange(),
 				},
 			},
 			"deployment_stage_id": schema.StringAttribute{


### PR DESCRIPTION
## Problem

When running a `-target` deployment on a service module (container, helm, application, etc.) while an upstream resource (e.g. `qovery_cluster`) had pending but unapplied changes, Terraform was deferring data sources to apply time. This caused `environment_id` to become `(known after apply)` at plan time. Since `environment_id` had `RequiresReplace()`, Terraform planned a destroy+recreate of all affected services — even though the environment hadn't actually changed.

This triggered a production incident for a customer who ran a targeted apply while cluster drift was present.

## Root cause

`environment_id` only had `RequiresReplace()` with no `UseStateForUnknown()`. When the planned value became unknown due to upstream deferred data sources, there was nothing to preserve the known state value, so Terraform treated it as a change and forced replacement.

## Fix

Add `UseStateForUnknown()` before `RequiresReplace()` on `environment_id` across all 6 service resources: container, helm, application, job, database, terraform_service.

**Behavior after fix:**
- If `environment_id` becomes unknown at plan time (upstream drift, deferred data sources): `UseStateForUnknown()` substitutes the known state value → `RequiresReplace()` sees no change → no replacement triggered ✅
- If `environment_id` actually changes to a different known value: `UseStateForUnknown()` does not activate → `RequiresReplace()` triggers replacement as expected ✅

## Testing

All 694 unit tests pass. Run `task docs` before merging to regenerate provider documentation.