### PR TITLE
fix(terraform-service): preserve null description 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.0
 	github.com/pkg/errors v0.9.1
-	github.com/qovery/qovery-client-go v0.0.0-20260522073311-d736df0494b3
+	github.com/qovery/qovery-client-go v0.0.0-20260602073019-2992b9dd5b45
 	github.com/schollz/progressbar/v3 v3.18.0
 	github.com/sethvargo/go-envconfig v1.1.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -195,8 +195,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
-github.com/qovery/qovery-client-go v0.0.0-20260522073311-d736df0494b3 h1:Q+Glyf7+UiGAb3ErttqsUTwTetz9rimWpbZJuBpvxxY=
-github.com/qovery/qovery-client-go v0.0.0-20260522073311-d736df0494b3/go.mod h1:mcXeQtxR4AIGIBaWLhy52S16UwL8/1fcDywDuSK1BZ4=
+github.com/qovery/qovery-client-go v0.0.0-20260602073019-2992b9dd5b45 h1:SnMzQfXxBM8oowkXafDtiHJq57znC54vsA7n4HYm3Q8=
+github.com/qovery/qovery-client-go v0.0.0-20260602073019-2992b9dd5b45/go.mod h1:mcXeQtxR4AIGIBaWLhy52S16UwL8/1fcDywDuSK1BZ4=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/internal/infrastructure/repositories/qoveryapi/credentials_qoveryapi_models.go
+++ b/internal/infrastructure/repositories/qoveryapi/credentials_qoveryapi_models.go
@@ -93,10 +93,10 @@ func newQoveryScalewayCredentialsRequestFromDomain(request credentials.UpsertSca
 
 // newQoveryGcpCredentialsRequestFromDomain takes the domain request credentials.UpsertGcpRequest and turns it into a qovery.GcpCredentialsRequest to make the api call.
 func newQoveryGcpCredentialsRequestFromDomain(request credentials.UpsertGcpRequest) qovery.GcpCredentialsRequest {
-	return qovery.GcpCredentialsRequest{
+	return qovery.GcpServiceAccountKeyCredentialsRequestAsGcpCredentialsRequest(&qovery.GcpServiceAccountKeyCredentialsRequest{
 		Name:           request.Name,
 		GcpCredentials: request.GcpCredentials,
-	}
+	})
 }
 
 // newQoveryAzureCredentialsRequestFromDomain takes the domain request credentials.UpsertAzureRequest and turns it into a qovery.AzureCredentialsRequest to make the api call.

--- a/qovery/resource_terraform_service_model.go
+++ b/qovery/resource_terraform_service_model.go
@@ -247,7 +247,7 @@ func convertDomainTerraformServiceToTerraformService(plan TerraformService, ts *
 		DeploymentStageId:     FromString(ts.DeploymentStageID),
 		IsSkipped:             FromBool(ts.IsSkipped),
 		Name:                  FromString(ts.Name),
-		Description:           FromStringPointer(ts.Description),
+		Description:           normalizeOptionalDescription(plan.Description, ts.Description),
 		AutoDeploy:            FromBool(ts.AutoDeploy),
 		TerraformAction:       FromString(string(ts.TerraformAction)),
 		GitRepository:         fromGitRepository(ts.GitRepository),
@@ -265,6 +265,17 @@ func convertDomainTerraformServiceToTerraformService(plan TerraformService, ts *
 		CreatedAt:             FromTime(ts.CreatedAt),
 		UpdatedAt:             FromTimePointer(ts.UpdatedAt),
 	}
+}
+
+// normalizeOptionalDescription preserves a null description when the API echoes
+// nil or an empty string. The API normalizes a missing description to "", which
+// would otherwise trigger "provider produced inconsistent result after apply"
+// since the schema is Optional (not Computed).
+func normalizeOptionalDescription(prior types.String, apiVal *string) types.String {
+	if (apiVal == nil || *apiVal == "") && prior.IsNull() {
+		return types.StringNull()
+	}
+	return FromStringPointer(apiVal)
 }
 
 // fromGitRepository converts domain git repository to Terraform


### PR DESCRIPTION
  `qovery_terraform_service` fails on apply with:

  > Error: Provider produced inconsistent result after apply
  > `.description`: was null, but now `cty.StringVal("")`

  whenever `description` is omitted from the config.

  **Root cause is in response parsing.** The OpenAPI contract says:
  - `TerraformRequest.description`: `required`, `string`, not nullable
  - `TerraformResponse.description`: optional, `string`, not nullable

  So the request layer correctly sends `""` for an unset description, and the API echoes `""` back. The provider then maps that to `types.StringValue("")`, which doesn't match the planned `null` — and the framework rejects the apply because the
  schema is `Optional` (not `Computed`).

  ## Fix

  In `convertDomainTerraformServiceToTerraformService`, treat a `nil`/`""` response as `null` when the prior plan/state was `null`. Otherwise pass the response value through unchanged.

  This mirrors the same treatment in `convertDomainDeploymentStageToDeploymentStage` (in tree since 2023, PR #180), which exists for the same API quirk.
  
  
  **NOTE**
  Bumped qovery client to fix the CI
  ```
   Error: internal/infrastructure/repositories/qoveryapi/credentials_qoveryapi_models.go:97:3: unknown field Name in struct literal of type qovery.GcpCredentialsRequest
Error: internal/infrastructure/repositories/qoveryapi/credentials_qoveryapi_models.go:98:3: unknown field GcpCredentials in struct literal of type qovery.GcpCredentialsRequest
```