### PR TITLE
fix: remove extra content-type header

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -20,7 +20,6 @@ func New(token string, version string, host string) *Client {
 func NewQoveryAPIClient(token string, version string, host string) *qovery.APIClient {
 	cfg := qovery.NewConfiguration()
 	cfg.AddDefaultHeader("Authorization", fmt.Sprintf("Token %s", token))
-	cfg.AddDefaultHeader("content-type", "application/json")
 
 	cfg.UserAgent = fmt.Sprintf("Terraform provider %s", version)
 	cfg.Servers = qovery.ServerConfigurations{

--- a/internal/infrastructure/repositories/qoveryapi/qoveryapi.go
+++ b/internal/infrastructure/repositories/qoveryapi/qoveryapi.go
@@ -88,7 +88,6 @@ type QoveryAPI struct {
 func New(configs ...Configuration) (*QoveryAPI, error) {
 	// Initialize the qovery api client.
 	cfg := qovery.NewConfiguration()
-	cfg.AddDefaultHeader("content-type", "application/json")
 	apiClient := qovery.NewAPIClient(cfg)
 
 	// Initialize repositories implementations.


### PR DESCRIPTION
It is already set by the client sdk, and as we are adding the header name is lower case it cause is double

```
Root cause

  The content-type header gets sent twice because of a casing mismatch combined with how the generated client merges default headers, in qovery-client-go/client.go:

  // 1. Per-request: the generated API methods set this (capitalized, via http.Header canonical key)

  // 2. In prepareRequest, header params are written first:
  headers := http.Header{}
  for h, v := range headerParams {
      headers[h] = []string{v}        // sets "Content-Type"
  }
  localVarRequest.Header = headers

  // 3. THEN default headers are appended with .Add():
  for header, value := range c.cfg.DefaultHeader {
      localVarRequest.Header.Add(header, value)   // <-- the culprit
  }

  The decisive detail is Header.Add vs Header.Set:

  - Header.Add("content-type", ...) canonicalizes the key to Content-Type (Go's http.Header does this for both Add and Set), then appends to the existing slice instead of replacing it.
  - So the "content-type" default header you registered in your two call sites collapses onto the same canonical Content-Type key that the API method already set — and because it's Add, not Set, you end
  up with Content-Type: application/json, application/json (two values on the header).

  So your own cfg.AddDefaultHeader("content-type", "application/json") is redundant and harmful: the generated client already sets Content-Type per request (via selectHeaderContentType, which prefers
  application/json). Your default header just gets appended a second time.
```