### PR TITLE
fix(blueprint): bump qovery-client-go to fix blueprint_id snake_case 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.0
 	github.com/pkg/errors v0.9.1
-	github.com/qovery/qovery-client-go v0.0.0-20260608093041-a512435d7797
+	github.com/qovery/qovery-client-go v0.0.0-20260609115652-6441e57b57d0
 	github.com/schollz/progressbar/v3 v3.18.0
 	github.com/sethvargo/go-envconfig v1.1.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -201,6 +201,8 @@ github.com/qovery/qovery-client-go v0.0.0-20260608085047-43375cf912c0 h1:wWXEyLz
 github.com/qovery/qovery-client-go v0.0.0-20260608085047-43375cf912c0/go.mod h1:mcXeQtxR4AIGIBaWLhy52S16UwL8/1fcDywDuSK1BZ4=
 github.com/qovery/qovery-client-go v0.0.0-20260608093041-a512435d7797 h1:lqht4Gca4rPyrUV/34nJZ4fm0Od29YrchVMi84509vk=
 github.com/qovery/qovery-client-go v0.0.0-20260608093041-a512435d7797/go.mod h1:mcXeQtxR4AIGIBaWLhy52S16UwL8/1fcDywDuSK1BZ4=
+github.com/qovery/qovery-client-go v0.0.0-20260609115652-6441e57b57d0 h1:Aym0jIz4MHNx4NooERldZuedlRGDVj1z7gACCzgQ2ho=
+github.com/qovery/qovery-client-go v0.0.0-20260609115652-6441e57b57d0/go.mod h1:mcXeQtxR4AIGIBaWLhy52S16UwL8/1fcDywDuSK1BZ4=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=


### PR DESCRIPTION

The previous client version had `json:"blueprintId"` (camelCase) on TerraformResponse and HelmResponse, causing q-core to silently drop the field on reads and the provider to return null on writes 
