### PR TITLE
feat(QOV-2019): warn on unknown advanced_settings_json keys + fix perpetual diff

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -31,3 +31,9 @@ func NewQoveryAPIClient(token string, version string, host string) *qovery.APICl
 
 	return qovery.NewAPIClient(cfg)
 }
+
+// GetConfig returns the underlying qovery-client configuration. Used by resources that need to
+// build a ServiceAdvancedSettingsService for plan-time validation.
+func (c *Client) GetConfig() *qovery.Configuration {
+	return c.api.GetConfig()
+}

--- a/internal/domain/advanced_settings/normalize.go
+++ b/internal/domain/advanced_settings/normalize.go
@@ -62,5 +62,23 @@ func computeOverriddenSettings(
 			overridden[name] = normalizeJSONValue(stateValue)
 		}
 	}
+
+	// Preserve "unknown" overrides: keys present in state but absent from both the API
+	// response (current) and the defaults. The API does not recognize these keys for this
+	// service type, so it never returns them. Dropping them here would cause a perpetual
+	// diff: state loses the key on refresh, then the next plan re-adds it from config.
+	// Carrying the state value forward keeps the refreshed value equal to the configured
+	// value. On import state is empty, so this loop is a no-op and import behavior is
+	// unchanged.
+	for name, stateValue := range state {
+		if _, inCurrent := current[name]; inCurrent {
+			continue
+		}
+		if _, inDefaults := defaults[name]; inDefaults {
+			continue
+		}
+		overridden[name] = normalizeJSONValue(stateValue)
+	}
+
 	return overridden
 }

--- a/internal/domain/advanced_settings/normalize_test.go
+++ b/internal/domain/advanced_settings/normalize_test.go
@@ -185,6 +185,28 @@ func TestComputeOverriddenSettings(t *testing.T) {
 			isTriggeredFromImport: true,
 			expected:              map[string]any{"new_setting": "value"},
 		},
+		{
+			testName: "unknown_state_key_absent_from_current_and_defaults_is_preserved",
+			current:  map[string]any{"static_ip": true},
+			defaults: map[string]any{"static_ip": false},
+			state:    map[string]any{"static_ip": true, "network.dns.ndots": float64(1)},
+			expected: map[string]any{"static_ip": true, "network.dns.ndots": float64(1)},
+		},
+		{
+			testName: "unknown_state_key_value_is_normalized",
+			current:  map[string]any{},
+			defaults: map[string]any{},
+			state:    map[string]any{"security.automount_service_account_token": "true"},
+			expected: map[string]any{"security.automount_service_account_token": true},
+		},
+		{
+			testName:              "import_does_not_resurrect_unknown_keys",
+			current:               map[string]any{"static_ip": true},
+			defaults:              map[string]any{"static_ip": false},
+			state:                 map[string]any{},
+			isTriggeredFromImport: true,
+			expected:              map[string]any{"static_ip": true},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/domain/advanced_settings/service_advanced_settings.go
+++ b/internal/domain/advanced_settings/service_advanced_settings.go
@@ -288,12 +288,14 @@ func (c ServiceAdvancedSettingsService) fetchDefaultAdvancedSettings(serviceType
 }
 
 // defaultSettingKeys returns the set of valid advanced setting keys for a service type,
-// caching the result per service type.
+// caching the result per service type. The cache lock is released during the HTTP fetch so
+// concurrent plan-time validations for other service types are not serialized behind it; a
+// double-check on re-lock avoids storing a redundant result if another goroutine raced us.
 func (c ServiceAdvancedSettingsService) defaultSettingKeys(serviceType int) (map[string]struct{}, error) {
 	c.cacheMu.Lock()
-	defer c.cacheMu.Unlock()
-
-	if cached, ok := c.defaultKeysCache[serviceType]; ok {
+	cached, ok := c.defaultKeysCache[serviceType]
+	c.cacheMu.Unlock()
+	if ok {
 		return cached, nil
 	}
 
@@ -305,6 +307,12 @@ func (c ServiceAdvancedSettingsService) defaultSettingKeys(serviceType int) (map
 	keys := make(map[string]struct{}, len(defaults))
 	for k := range defaults {
 		keys[k] = struct{}{}
+	}
+
+	c.cacheMu.Lock()
+	defer c.cacheMu.Unlock()
+	if cached, ok := c.defaultKeysCache[serviceType]; ok {
+		return cached, nil
 	}
 	c.defaultKeysCache[serviceType] = keys
 	return keys, nil

--- a/internal/domain/advanced_settings/service_advanced_settings.go
+++ b/internal/domain/advanced_settings/service_advanced_settings.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"sort"
+	"sync"
 
 	"github.com/pkg/errors"
 	"github.com/qovery/qovery-client-go"
@@ -14,10 +16,20 @@ import (
 
 type ServiceAdvancedSettingsService struct {
 	apiConfig *qovery.Configuration
+
+	// defaultKeysCache caches the set of valid advanced setting keys per service type.
+	// The default set is static for a provider run. It is a reference-type map guarded by
+	// a pointer mutex so that value-receiver method copies share the same cache.
+	defaultKeysCache map[int]map[string]struct{}
+	cacheMu          *sync.Mutex
 }
 
 func NewServiceAdvancedSettingsService(apiConfig *qovery.Configuration) *ServiceAdvancedSettingsService {
-	return &ServiceAdvancedSettingsService{apiConfig: apiConfig}
+	return &ServiceAdvancedSettingsService{
+		apiConfig:        apiConfig,
+		defaultKeysCache: make(map[int]map[string]struct{}),
+		cacheMu:          &sync.Mutex{},
+	}
 }
 
 // Compute the URL to GET or PUT advanced settings for any service type
@@ -79,37 +91,6 @@ func (c ServiceAdvancedSettingsService) ReadServiceAdvancedSettings(serviceType 
 	}
 
 	//
-	// Get default service advanced settings
-	defaultAdvancedSettingsUrl, err := c.computeDefaultServiceAdvancedSettingsUrl(serviceType)
-	if err != nil {
-		return nil, err
-	}
-	getDefaultAdvancedSettingsRequest, err := http.NewRequest("GET", *defaultAdvancedSettingsUrl, nil)
-	if err != nil {
-		return nil, err
-	}
-	getDefaultAdvancedSettingsRequest.Header.Set("Authorization", apiToken)
-	getDefaultAdvancedSettingsRequest.Header.Set("Content-Type", "application/json")
-	getDefaultAdvancedSettingsRequest.Header.Set("User-Agent", c.apiConfig.UserAgent)
-
-	respGetDefaultAdvancedSettings, err := httpClient.Do(getDefaultAdvancedSettingsRequest)
-	if err != nil {
-		return nil, err
-	}
-	defer respGetDefaultAdvancedSettings.Body.Close()
-
-	if respGetDefaultAdvancedSettings.StatusCode >= 400 {
-		return nil, errors.New("Cannot get default advanced settings :" + respGetDefaultAdvancedSettings.Status)
-	}
-
-	defaultServiceAdvancedSettingsJson, err := io.ReadAll(respGetDefaultAdvancedSettings.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	defaultAdvancedSettingsJsonString := string(defaultServiceAdvancedSettingsJson)
-
-	//
 	// Get service advanced settings
 	urlAdvancedSettings, err := c.computeServiceAdvancedSettingsUrl(serviceType, serviceId)
 	if err != nil {
@@ -152,8 +133,8 @@ func (c ServiceAdvancedSettingsService) ReadServiceAdvancedSettings(serviceType 
 		return nil, err
 	}
 
-	defaultAdvancedSettingsHashMap := make(map[string]any)
-	if err := json.Unmarshal([]byte(defaultAdvancedSettingsJsonString), &defaultAdvancedSettingsHashMap); err != nil {
+	defaultAdvancedSettingsHashMap, err := c.fetchDefaultAdvancedSettings(serviceType)
+	if err != nil {
 		return nil, err
 	}
 
@@ -266,4 +247,99 @@ func (c ServiceAdvancedSettingsService) UpdateServiceAdvancedSettings(serviceTyp
 	}
 
 	return nil
+}
+
+// fetchDefaultAdvancedSettings fetches and parses the default advanced settings for a service
+// type. These represent the full set of valid keys for that service type.
+func (c ServiceAdvancedSettingsService) fetchDefaultAdvancedSettings(serviceType int) (map[string]any, error) {
+	defaultAdvancedSettingsUrl, err := c.computeDefaultServiceAdvancedSettingsUrl(serviceType)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", *defaultAdvancedSettingsUrl, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", c.apiConfig.DefaultHeader["Authorization"])
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", c.apiConfig.UserAgent)
+
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return nil, errors.New("Cannot get default advanced settings :" + resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	defaults := make(map[string]any)
+	if err := json.Unmarshal(body, &defaults); err != nil {
+		return nil, err
+	}
+	return defaults, nil
+}
+
+// defaultSettingKeys returns the set of valid advanced setting keys for a service type,
+// caching the result per service type.
+func (c ServiceAdvancedSettingsService) defaultSettingKeys(serviceType int) (map[string]struct{}, error) {
+	c.cacheMu.Lock()
+	defer c.cacheMu.Unlock()
+
+	if cached, ok := c.defaultKeysCache[serviceType]; ok {
+		return cached, nil
+	}
+
+	defaults, err := c.fetchDefaultAdvancedSettings(serviceType)
+	if err != nil {
+		return nil, err
+	}
+
+	keys := make(map[string]struct{}, len(defaults))
+	for k := range defaults {
+		keys[k] = struct{}{}
+	}
+	c.defaultKeysCache[serviceType] = keys
+	return keys, nil
+}
+
+// computeUnknownKeys returns the keys in advancedSettings that are absent from validKeys,
+// sorted for deterministic output.
+func computeUnknownKeys(validKeys map[string]struct{}, advancedSettings map[string]any) []string {
+	unknown := make([]string, 0)
+	for key := range advancedSettings {
+		if _, ok := validKeys[key]; !ok {
+			unknown = append(unknown, key)
+		}
+	}
+	sort.Strings(unknown)
+	return unknown
+}
+
+// UnknownSettingKeys returns the advanced setting keys present in advancedSettingsJson that are
+// not valid for the given service type (absent from that type's default settings). It returns
+// nil for an empty input.
+func (c ServiceAdvancedSettingsService) UnknownSettingKeys(serviceType int, advancedSettingsJson string) ([]string, error) {
+	if advancedSettingsJson == "" || advancedSettingsJson == "{}" {
+		return nil, nil
+	}
+
+	validKeys, err := c.defaultSettingKeys(serviceType)
+	if err != nil {
+		return nil, err
+	}
+
+	provided := make(map[string]any)
+	if err := json.Unmarshal([]byte(advancedSettingsJson), &provided); err != nil {
+		return nil, err
+	}
+
+	return computeUnknownKeys(validKeys, provided), nil
 }

--- a/internal/domain/advanced_settings/unknown_keys_test.go
+++ b/internal/domain/advanced_settings/unknown_keys_test.go
@@ -1,0 +1,56 @@
+//go:build unit && !integration
+// +build unit,!integration
+
+package advanced_settings
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestComputeUnknownKeys(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		testName         string
+		validKeys        map[string]struct{}
+		advancedSettings map[string]any
+		expected         []string
+	}{
+		{
+			testName:         "all_keys_valid_returns_empty",
+			validKeys:        map[string]struct{}{"network.ingress.cors_enabled": {}},
+			advancedSettings: map[string]any{"network.ingress.cors_enabled": true},
+			expected:         []string{},
+		},
+		{
+			testName:         "unknown_keys_returned_sorted",
+			validKeys:        map[string]struct{}{"network.ingress.cors_enabled": {}},
+			advancedSettings: map[string]any{"security.service_account_name": "x", "network.dns.ndots": float64(1)},
+			expected:         []string{"network.dns.ndots", "security.service_account_name"},
+		},
+		{
+			testName:         "mixed_valid_and_unknown",
+			validKeys:        map[string]struct{}{"network.ingress.cors_enabled": {}},
+			advancedSettings: map[string]any{"network.ingress.cors_enabled": true, "network.dns.ndots": float64(1)},
+			expected:         []string{"network.dns.ndots"},
+		},
+		{
+			testName:         "empty_settings_returns_empty",
+			validKeys:        map[string]struct{}{"a": {}},
+			advancedSettings: map[string]any{},
+			expected:         []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.testName, func(t *testing.T) {
+			t.Parallel()
+			result := computeUnknownKeys(tc.validKeys, tc.advancedSettings)
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("computeUnknownKeys() = %v, want %v", result, tc.expected)
+			}
+		})
+	}
+}

--- a/qovery/advanced_settings_validation.go
+++ b/qovery/advanced_settings_validation.go
@@ -18,7 +18,8 @@ const advancedSettingsJSONAttr = "advanced_settings_json"
 
 // warnUnknownAdvancedSettings adds a plan-time warning for each key in advanced_settings_json
 // that is not valid for the given service type. It never blocks the plan: a null/unknown
-// attribute or any fetch error degrades silently to "no warning".
+// attribute or any error (config read, defaults fetch, or JSON parse) degrades silently to
+// "no warning".
 func warnUnknownAdvancedSettings(
 	ctx context.Context,
 	svc *advanced_settings.ServiceAdvancedSettingsService,
@@ -41,7 +42,7 @@ func warnUnknownAdvancedSettings(
 
 	unknown, err := svc.UnknownSettingKeys(serviceType, raw.ValueString())
 	if err != nil {
-		tflog.Warn(ctx, "could not validate advanced settings keys", map[string]interface{}{
+		tflog.Warn(ctx, "could not validate advanced settings keys", map[string]any{
 			"error": err.Error(),
 		})
 		return

--- a/qovery/advanced_settings_validation.go
+++ b/qovery/advanced_settings_validation.go
@@ -50,7 +50,7 @@ func warnUnknownAdvancedSettings(
 	for _, key := range unknown {
 		diags.AddAttributeWarning(
 			path.Root(advancedSettingsJSONAttr),
-			"Unknown advanced setting",
+			fmt.Sprintf("Unknown advanced setting %q", key),
 			fmt.Sprintf(
 				"The advanced setting %q is not a valid setting for this service type and will "+
 					"have no effect. Remove it from advanced_settings_json to clear this warning. "+

--- a/qovery/advanced_settings_validation.go
+++ b/qovery/advanced_settings_validation.go
@@ -1,0 +1,62 @@
+package qovery
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"github.com/qovery/terraform-provider-qovery/internal/domain/advanced_settings"
+)
+
+// advancedSettingsJSONAttr is the attribute name shared by all service resources.
+const advancedSettingsJSONAttr = "advanced_settings_json"
+
+// warnUnknownAdvancedSettings adds a plan-time warning for each key in advanced_settings_json
+// that is not valid for the given service type. It never blocks the plan: a null/unknown
+// attribute or any fetch error degrades silently to "no warning".
+func warnUnknownAdvancedSettings(
+	ctx context.Context,
+	svc *advanced_settings.ServiceAdvancedSettingsService,
+	serviceType int,
+	cfg tfsdk.Config,
+	diags *diag.Diagnostics,
+) {
+	if svc == nil {
+		return
+	}
+
+	var raw types.String
+	if d := cfg.GetAttribute(ctx, path.Root(advancedSettingsJSONAttr), &raw); d.HasError() {
+		// Reading config failed (e.g. during destroy when config is null). Nothing to validate.
+		return
+	}
+	if raw.IsNull() || raw.IsUnknown() || raw.ValueString() == "" {
+		return
+	}
+
+	unknown, err := svc.UnknownSettingKeys(serviceType, raw.ValueString())
+	if err != nil {
+		tflog.Warn(ctx, "could not validate advanced settings keys", map[string]interface{}{
+			"error": err.Error(),
+		})
+		return
+	}
+
+	for _, key := range unknown {
+		diags.AddAttributeWarning(
+			path.Root(advancedSettingsJSONAttr),
+			"Unknown advanced setting",
+			fmt.Sprintf(
+				"The advanced setting %q is not a valid setting for this service type and will "+
+					"have no effect. Remove it from advanced_settings_json to clear this warning. "+
+					"See the service's advanced settings documentation for the list of valid keys.",
+				key,
+			),
+		)
+	}
+}

--- a/qovery/provider.go
+++ b/qovery/provider.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/qovery/terraform-provider-qovery/client"
 	"github.com/qovery/terraform-provider-qovery/internal/application/services"
+	"github.com/qovery/terraform-provider-qovery/internal/domain/advanced_settings"
 	"github.com/qovery/terraform-provider-qovery/internal/domain/annotations_group"
 	"github.com/qovery/terraform-provider-qovery/internal/domain/argoCdCredentials"
 	"github.com/qovery/terraform-provider-qovery/internal/domain/argoCdDestinationClusterMapping"
@@ -109,6 +110,10 @@ type qProvider struct {
 	// terraformServiceService is an instance of a terraformservice.Service that handles the domain logic.
 	terraformServiceService terraformservice.Service
 
+	// advancedSettingsService validates advanced_settings_json keys at plan time.
+	// It holds a per-service-type cache, so it is constructed once and shared across resources.
+	advancedSettingsService *advanced_settings.ServiceAdvancedSettingsService
+
 	// argoCdCredentialsService is an instance of an argoCdCredentials.Service that handles the domain logic.
 	argoCdCredentialsService argoCdCredentials.Service
 
@@ -182,6 +187,7 @@ func (p *qProvider) Configure(ctx context.Context, req provider.ConfigureRequest
 	// Create a new Qovery client and set it to the provider client
 	p.configured = true
 	p.client = client.New(token, p.version, host)
+	p.advancedSettingsService = advanced_settings.NewServiceAdvancedSettingsService(p.client.GetConfig())
 	p.organizationService = domainServices.Organization
 	p.awsCredentialsService = domainServices.CredentialsAws
 	p.scalewayCredentialsService = domainServices.CredentialsScaleway

--- a/qovery/resource_application.go
+++ b/qovery/resource_application.go
@@ -21,6 +21,8 @@ import (
 	"github.com/qovery/qovery-client-go"
 
 	"github.com/qovery/terraform-provider-qovery/client"
+	"github.com/qovery/terraform-provider-qovery/internal/domain"
+	"github.com/qovery/terraform-provider-qovery/internal/domain/advanced_settings"
 	"github.com/qovery/terraform-provider-qovery/internal/domain/port"
 	"github.com/qovery/terraform-provider-qovery/internal/domain/storage"
 	"github.com/qovery/terraform-provider-qovery/qovery/descriptions"
@@ -31,6 +33,7 @@ import (
 var (
 	_ resource.ResourceWithConfigure   = &applicationResource{}
 	_ resource.ResourceWithImportState = applicationResource{}
+	_ resource.ResourceWithModifyPlan  = applicationResource{}
 )
 
 var (
@@ -67,7 +70,8 @@ var (
 )
 
 type applicationResource struct {
-	client *client.Client
+	client                  *client.Client
+	advancedSettingsService *advanced_settings.ServiceAdvancedSettingsService
 }
 
 func newApplicationResource() resource.Resource {
@@ -94,6 +98,7 @@ func (r *applicationResource) Configure(_ context.Context, req resource.Configur
 	}
 
 	r.client = provider.client
+	r.advancedSettingsService = provider.advancedSettingsService
 }
 
 func (r applicationResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -889,4 +894,8 @@ func (r applicationResource) Delete(ctx context.Context, req resource.DeleteRequ
 // ImportState imports a qovery application resource using its id
 func (r applicationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func (r applicationResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	warnUnknownAdvancedSettings(ctx, r.advancedSettingsService, domain.APPLICATION, req.Config, &resp.Diagnostics)
 }

--- a/qovery/resource_container.go
+++ b/qovery/resource_container.go
@@ -18,6 +18,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
+	"github.com/qovery/terraform-provider-qovery/internal/domain"
+	"github.com/qovery/terraform-provider-qovery/internal/domain/advanced_settings"
 	"github.com/qovery/terraform-provider-qovery/internal/domain/container"
 	"github.com/qovery/terraform-provider-qovery/internal/domain/port"
 	"github.com/qovery/terraform-provider-qovery/internal/domain/storage"
@@ -29,10 +31,12 @@ import (
 var (
 	_ resource.ResourceWithConfigure   = &containerResource{}
 	_ resource.ResourceWithImportState = containerResource{}
+	_ resource.ResourceWithModifyPlan  = containerResource{}
 )
 
 type containerResource struct {
-	containerService container.Service
+	containerService        container.Service
+	advancedSettingsService *advanced_settings.ServiceAdvancedSettingsService
 }
 
 func newContainerResource() resource.Resource {
@@ -59,6 +63,7 @@ func (r *containerResource) Configure(_ context.Context, req resource.ConfigureR
 	}
 
 	r.containerService = provider.containerService
+	r.advancedSettingsService = provider.advancedSettingsService
 }
 
 func (r containerResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -769,4 +774,8 @@ func (r containerResource) Delete(ctx context.Context, req resource.DeleteReques
 // ImportState imports a qovery container resource using its id
 func (r containerResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func (r containerResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	warnUnknownAdvancedSettings(ctx, r.advancedSettingsService, domain.CONTAINER, req.Config, &resp.Diagnostics)
 }

--- a/qovery/resource_helm.go
+++ b/qovery/resource_helm.go
@@ -19,23 +19,26 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
+	"github.com/qovery/terraform-provider-qovery/internal/domain"
+	"github.com/qovery/terraform-provider-qovery/internal/domain/advanced_settings"
+	"github.com/qovery/terraform-provider-qovery/internal/domain/helm"
 	"github.com/qovery/terraform-provider-qovery/internal/domain/port"
 	"github.com/qovery/terraform-provider-qovery/qovery/descriptions"
 	"github.com/qovery/terraform-provider-qovery/qovery/validators"
-
-	"github.com/qovery/terraform-provider-qovery/internal/domain/helm"
 )
 
 // Ensure provider defined types fully satisfy terraform framework interfaces.
 var (
 	_ resource.ResourceWithConfigure   = &helmResource{}
 	_ resource.ResourceWithImportState = helmResource{}
+	_ resource.ResourceWithModifyPlan  = helmResource{}
 )
 
 var helmPortProtocols = clientEnumToStringArray(helm.AllowedProtocols)
 
 type helmResource struct {
-	helmService helm.Service
+	helmService             helm.Service
+	advancedSettingsService *advanced_settings.ServiceAdvancedSettingsService
 }
 
 func newHelmResource() resource.Resource {
@@ -62,6 +65,7 @@ func (r *helmResource) Configure(_ context.Context, req resource.ConfigureReques
 	}
 
 	r.helmService = provider.helmService
+	r.advancedSettingsService = provider.advancedSettingsService
 }
 
 func (r helmResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -824,4 +828,8 @@ func (r helmResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 // ImportState imports a qovery helm resource using its id
 func (r helmResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func (r helmResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	warnUnknownAdvancedSettings(ctx, r.advancedSettingsService, domain.HELM, req.Config, &resp.Diagnostics)
 }

--- a/qovery/resource_job.go
+++ b/qovery/resource_job.go
@@ -19,6 +19,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/qovery/qovery-client-go"
 
+	"github.com/qovery/terraform-provider-qovery/internal/domain"
+	"github.com/qovery/terraform-provider-qovery/internal/domain/advanced_settings"
 	"github.com/qovery/terraform-provider-qovery/internal/domain/job"
 	"github.com/qovery/terraform-provider-qovery/internal/domain/port"
 	"github.com/qovery/terraform-provider-qovery/qovery/descriptions"
@@ -29,10 +31,12 @@ import (
 var (
 	_ resource.ResourceWithConfigure   = &jobResource{}
 	_ resource.ResourceWithImportState = jobResource{}
+	_ resource.ResourceWithModifyPlan  = jobResource{}
 )
 
 type jobResource struct {
-	jobService job.Service
+	jobService              job.Service
+	advancedSettingsService *advanced_settings.ServiceAdvancedSettingsService
 }
 
 func newJobResource() resource.Resource {
@@ -59,6 +63,7 @@ func (r *jobResource) Configure(_ context.Context, req resource.ConfigureRequest
 	}
 
 	r.jobService = provider.jobService
+	r.advancedSettingsService = provider.advancedSettingsService
 }
 
 func (r jobResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -820,4 +825,8 @@ func (r jobResource) Delete(ctx context.Context, req resource.DeleteRequest, res
 // ImportState imports a qovery job resource using its id
 func (r jobResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func (r jobResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	warnUnknownAdvancedSettings(ctx, r.advancedSettingsService, domain.JOB, req.Config, &resp.Diagnostics)
 }

--- a/qovery/resource_terraform_service.go
+++ b/qovery/resource_terraform_service.go
@@ -16,6 +16,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
+	"github.com/qovery/terraform-provider-qovery/internal/domain"
+	"github.com/qovery/terraform-provider-qovery/internal/domain/advanced_settings"
 	"github.com/qovery/terraform-provider-qovery/internal/domain/terraformservice"
 	"github.com/qovery/terraform-provider-qovery/qovery/descriptions"
 	"github.com/qovery/terraform-provider-qovery/qovery/validators"
@@ -35,6 +37,7 @@ var (
 
 type terraformServiceResource struct {
 	terraformServiceService terraformservice.Service
+	advancedSettingsService *advanced_settings.ServiceAdvancedSettingsService
 }
 
 func newTerraformServiceResource() resource.Resource {
@@ -61,6 +64,7 @@ func (r *terraformServiceResource) Configure(_ context.Context, req resource.Con
 	}
 
 	r.terraformServiceService = provider.terraformServiceService
+	r.advancedSettingsService = provider.advancedSettingsService
 }
 
 func (r terraformServiceResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -523,6 +527,7 @@ func (r terraformServiceResource) ImportState(ctx context.Context, req resource.
 }
 
 func (r terraformServiceResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	warnUnknownAdvancedSettings(ctx, r.advancedSettingsService, domain.TERRAFORM, req.Config, &resp.Diagnostics)
 	// Prevent storage reduction
 	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
 		return


### PR DESCRIPTION
## Context

Reported by a customer (QOV-2019): some `advanced_settings_json` keys keep reappearing in every `terraform plan` after a successful `apply`. For example on a `qovery_helm`:

```
+ "network.dns.ndots"                          = 1
+ "security.automount_service_account_token"   = true
+ "security.service_account_name"              = "..."
+ "deployment.lifecycle.pre_stop_exec_command" = []
```

These keys are valid for container/application/job but not for helm. The API silently ignores keys it does not recognize for a service type, which produces a perpetual diff and gives the user no feedback that the keys are invalid.

### Root cause

`computeOverriddenSettings` (`internal/domain/advanced_settings/normalize.go`) only iterated over the keys returned by `GET /<type>/<id>/advancedSettings`. A key present in Terraform state but absent from that response was dropped on every refresh, then re-detected on the next plan. Forever.

## What this PR does

**Part 1: stop the perpetual diff.** `computeOverriddenSettings` now also preserves keys present in state but absent from both the API response and the defaults. The refreshed value equals the configured value, so the diff disappears. No-op on import.

**Part 2: warn on unknown keys at plan time.** A shared `ServiceAdvancedSettingsService` (held on the provider, with a per-service-type default-key cache) exposes `UnknownSettingKeys`. Each of the 5 service resources (application, container, job, helm, terraform_service) calls a shared `warnUnknownAdvancedSettings` helper from `ModifyPlan`, which adds a non-blocking attribute warning for each key that is invalid for that service type. The warning never blocks a plan or apply: a nil service, a config read error, or a defaults fetch error all degrade silently.

API-side validation was considered but deemed risky (it could break existing tolerated requests), so validation is done on the provider side as a warning.

## Testing

- New unit tests for `computeOverriddenSettings` (regression for the perpetual diff, including the import no-op) and for `computeUnknownKeys`.
- `go build ./...`, `go vet ./...`, `gofmt`, full unit suite: all clean.
- `go generate` (docs) produces no change (no schema change). `go mod tidy`: no change.

## Open items

- **golangci-lint** was not run locally (not installed in my environment); `gofmt` and `go vet` are clean. CI should cover the full linter.
- **Acceptance test deferred**: no API token available locally and acceptance tests create real cloud resources. The core logic is covered by unit tests. A `qovery_helm` acceptance test asserting a stable plan (no perpetual diff) with a container-only key is a good follow-up.

Ticket: QOV-2019
