### PR TITLE
feat(QOV-2023): add json_credentials support for GCP Artifact Registry

### DIFF
--- a/docs/resources/container_registry.md
+++ b/docs/resources/container_registry.md
@@ -71,8 +71,8 @@ resource "qovery_container_registry" "gcp_artifact_registry" {
   kind            = "GCP_ARTIFACT_REGISTRY"
   url             = "https://<region>-docker.pkg.dev"
   config = {
-    username = "_json_key"
-    password = "<gcp_service_account_json_key>"
+    region           = "<region>"
+    json_credentials = "<gcp_service_account_json_key>"
   }
   description = "GCP Artifact Registry"
 
@@ -118,8 +118,9 @@ resource "qovery_container_registry" "gcp_artifact_registry" {
 Optional:
 
 - `access_key_id` (String) AWS Access Key ID. Required if `kind` is `ECR` or `PUBLIC_ECR`.
+- `json_credentials` (String, Sensitive) GCP service account JSON key used to authenticate with the registry. Required if `kind` is `GCP_ARTIFACT_REGISTRY`.
 - `password` (String) Password or access token for authentication. Required if `kind` is `DOCKER_HUB`, `GITHUB_CR`, `GITHUB_ENTERPRISE_CR`, `GITLAB_CR`, or `GENERIC_CR`.
-- `region` (String) Region of the registry. Required if `kind` is `ECR` or `SCALEWAY_CR` (e.g. `us-east-1`, `fr-par`).
+- `region` (String) Region of the registry. Required if `kind` is `ECR`, `SCALEWAY_CR` or `GCP_ARTIFACT_REGISTRY` (e.g. `us-east-1`, `fr-par`).
 - `scaleway_access_key` (String) Scaleway Access Key. Required if `kind` is `SCALEWAY_CR`.
 - `scaleway_project_id` (String) Scaleway Project ID. Required if `kind` is `SCALEWAY_CR`.
 - `scaleway_secret_key` (String) Scaleway Secret Key. Required if `kind` is `SCALEWAY_CR`.

--- a/examples/resources/qovery_container_registry/resource.tf
+++ b/examples/resources/qovery_container_registry/resource.tf
@@ -57,8 +57,8 @@ resource "qovery_container_registry" "gcp_artifact_registry" {
   kind            = "GCP_ARTIFACT_REGISTRY"
   url             = "https://<region>-docker.pkg.dev"
   config = {
-    username = "_json_key"
-    password = "<gcp_service_account_json_key>"
+    region           = "<region>"
+    json_credentials = "<gcp_service_account_json_key>"
   }
   description = "GCP Artifact Registry"
 

--- a/internal/domain/registry/registry.go
+++ b/internal/domain/registry/registry.go
@@ -119,6 +119,7 @@ type UpsertRequestConfig struct {
 	ScalewayAccessKey *string
 	ScalewaySecretKey *string
 	ScalewayProjectId *string
+	JsonCredentials   *string
 	Username          *string
 	Password          *string
 }

--- a/internal/infrastructure/repositories/qoveryapi/container_registry_qoveryapi_models.go
+++ b/internal/infrastructure/repositories/qoveryapi/container_registry_qoveryapi_models.go
@@ -41,6 +41,7 @@ func newQoveryContainerRegistryRequestFromDomain(request registry.UpsertRequest)
 			ScalewayAccessKey: request.Config.ScalewayAccessKey,
 			ScalewaySecretKey: request.Config.ScalewaySecretKey,
 			ScalewayProjectId: request.Config.ScalewayProjectId,
+			JsonCredentials:   request.Config.JsonCredentials,
 			Username:          request.Config.Username,
 			Password:          request.Config.Password,
 		},

--- a/internal/infrastructure/repositories/qoveryapi/container_registry_qoveryapi_models_test.go
+++ b/internal/infrastructure/repositories/qoveryapi/container_registry_qoveryapi_models_test.go
@@ -97,3 +97,24 @@ func TestNewQoveryRegistryEditRequestFromDomain(t *testing.T) {
 		})
 	}
 }
+
+func TestNewQoveryRegistryRequestFromDomain_Config(t *testing.T) {
+	t.Parallel()
+
+	jsonCredentials := gofakeit.UUID()
+	region := gofakeit.Word()
+
+	req, err := newQoveryContainerRegistryRequestFromDomain(registry.UpsertRequest{
+		Name: gofakeit.Name(),
+		Kind: registry.KindGcpArtifactRegistry.String(),
+		URL:  gofakeit.URL(),
+		Config: registry.UpsertRequestConfig{
+			Region:          &region,
+			JsonCredentials: &jsonCredentials,
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, &region, req.Config.Region)
+	assert.Equal(t, &jsonCredentials, req.Config.JsonCredentials)
+}

--- a/qovery/resource_container_registry.go
+++ b/qovery/resource_container_registry.go
@@ -140,8 +140,8 @@ func (r containerRegistryResource) Schema(_ context.Context, _ resource.SchemaRe
 						Optional:            true,
 					},
 					"region": schema.StringAttribute{
-						Description:         "Required if kind is `ECR` or `SCALEWAY_CR`.",
-						MarkdownDescription: "Region of the registry. Required if `kind` is `ECR` or `SCALEWAY_CR` (e.g. `us-east-1`, `fr-par`).",
+						Description:         "Required if kind is `ECR`, `SCALEWAY_CR` or `GCP_ARTIFACT_REGISTRY`.",
+						MarkdownDescription: "Region of the registry. Required if `kind` is `ECR`, `SCALEWAY_CR` or `GCP_ARTIFACT_REGISTRY` (e.g. `us-east-1`, `fr-par`).",
 						Optional:            true,
 					},
 					"scaleway_access_key": schema.StringAttribute{
@@ -158,6 +158,12 @@ func (r containerRegistryResource) Schema(_ context.Context, _ resource.SchemaRe
 						Description:         "Required if kind is `SCALEWAY_CR`.",
 						MarkdownDescription: "Scaleway Project ID. Required if `kind` is `SCALEWAY_CR`.",
 						Optional:            true,
+					},
+					"json_credentials": schema.StringAttribute{
+						Description:         "Required if kind is `GCP_ARTIFACT_REGISTRY`.",
+						MarkdownDescription: "GCP service account JSON key used to authenticate with the registry. Required if `kind` is `GCP_ARTIFACT_REGISTRY`.",
+						Optional:            true,
+						Sensitive:           true,
 					},
 					"username": schema.StringAttribute{
 						Description:         "Required if kind is `DOCKER_HUB`, `GITHUB_CR`, `GITLAB_CR`, or `GENERIC_CR`.",

--- a/qovery/resource_container_registry_model.go
+++ b/qovery/resource_container_registry_model.go
@@ -23,6 +23,7 @@ type ContainerRegistryConfig struct {
 	ScalewayAccessKey types.String `tfsdk:"scaleway_access_key"`
 	ScalewaySecretKey types.String `tfsdk:"scaleway_secret_key"`
 	ScalewayProjectId types.String `tfsdk:"scaleway_project_id"`
+	JsonCredentials   types.String `tfsdk:"json_credentials"`
 	Username          types.String `tfsdk:"username"`
 	Password          types.String `tfsdk:"password"`
 }
@@ -48,6 +49,7 @@ func (p ContainerRegistry) toUpsertRequest() registry.UpsertRequest {
 			ScalewayAccessKey: ToStringPointer(p.Config.ScalewayAccessKey),
 			ScalewaySecretKey: ToStringPointer(p.Config.ScalewaySecretKey),
 			ScalewayProjectId: ToStringPointer(p.Config.ScalewayProjectId),
+			JsonCredentials:   ToStringPointer(p.Config.JsonCredentials),
 			Username:          ToStringPointer(p.Config.Username),
 			Password:          ToStringPointer(p.Config.Password),
 		}

--- a/qovery/resource_helm_repository_model.go
+++ b/qovery/resource_helm_repository_model.go
@@ -7,14 +7,28 @@ import (
 )
 
 type HelmRepository struct {
-	Id                  types.String             `tfsdk:"id"`
-	OrganizationId      types.String             `tfsdk:"organization_id"`
-	Name                types.String             `tfsdk:"name"`
-	Kind                types.String             `tfsdk:"kind"`
-	URL                 types.String             `tfsdk:"url"`
-	Description         types.String             `tfsdk:"description"`
-	Config              *ContainerRegistryConfig `tfsdk:"config"`
-	SkipTlsVerification types.Bool               `tfsdk:"skip_tls_verification"`
+	Id                  types.String          `tfsdk:"id"`
+	OrganizationId      types.String          `tfsdk:"organization_id"`
+	Name                types.String          `tfsdk:"name"`
+	Kind                types.String          `tfsdk:"kind"`
+	URL                 types.String          `tfsdk:"url"`
+	Description         types.String          `tfsdk:"description"`
+	Config              *HelmRepositoryConfig `tfsdk:"config"`
+	SkipTlsVerification types.Bool            `tfsdk:"skip_tls_verification"`
+}
+
+// HelmRepositoryConfig holds the authentication config for a helm repository.
+// It mirrors the container registry config but without GCP `json_credentials`,
+// which is not supported by the helm repository API.
+type HelmRepositoryConfig struct {
+	AccessKeyID       types.String `tfsdk:"access_key_id"`
+	SecretAccessKey   types.String `tfsdk:"secret_access_key"`
+	Region            types.String `tfsdk:"region"`
+	ScalewayAccessKey types.String `tfsdk:"scaleway_access_key"`
+	ScalewaySecretKey types.String `tfsdk:"scaleway_secret_key"`
+	ScalewayProjectId types.String `tfsdk:"scaleway_project_id"`
+	Username          types.String `tfsdk:"username"`
+	Password          types.String `tfsdk:"password"`
 }
 
 type HelmRepositoryDataSource struct {


### PR DESCRIPTION
## What

Add `json_credentials` support to the `qovery_container_registry` resource so GCP Artifact Registry registries can be managed through Terraform.

Jira: QOV-2023

## Why

A customer reported that terraforming a `GCP_ARTIFACT_REGISTRY` container registry fails. The API expects `region` + `json_credentials` for GCP, but the provider schema never exposed `json_credentials`, so Terraform rejected the attribute. The API and the Go client already support the field; only the provider was behind. Registries created through the Console worked because they hit the API directly.

## Changes

- Schema: add `json_credentials` (Sensitive) to the `config` block; update `region` description to mention `GCP_ARTIFACT_REGISTRY`.
- TF model `ContainerRegistryConfig` + `toUpsertRequest()`: map the new field.
- Domain `UpsertRequestConfig`: add `JsonCredentials`.
- qoveryapi mapping: pass `JsonCredentials` to the API client.
- Example: fix the GCP block to use the correct `region` + `json_credentials` (it previously showed the unsupported `username=_json_key` / `password` workaround).
- Regenerated docs.
- Unit regression test for the config mapping.

## Out of scope (follow-up)

GCP Workload Identity Federation fields (`gcp_credentials_type`, `project_id`, `service_account_email`, `workload_identity_provider_resource`, `token_lifetime_seconds`) and `role_arn` (ECR) / `azure_tenant_id` (AZURE_CR) are supported by the API but missing from the provider. They require a `qovery-client-go` bump (the pinned client only exposes `json_credentials` for GCP) and are left for a separate change.

## Testing

- `go build ./...`
- `go test ./internal/...` (all unit tests pass)
- `go vet`
- `go generate` (docs)
