### PR TITLE
fix(QOV-2044): return deployment restrictions on read and preserve empty collections on imported resources

### DIFF
--- a/qovery/deployment_restriction_model.go
+++ b/qovery/deployment_restriction_model.go
@@ -43,17 +43,23 @@ func FromDeploymentRestrictionList(initialState types.Set, deploymentRestriction
 		})
 	}
 
-	if len(list) == 0 && initialState.IsNull() {
-		return types.SetNull(deploymentRestrictionObjectType)
-	}
-
-	if len(initialState.Elements()) == 0 {
-		return types.SetValueMust(deploymentRestrictionObjectType, []attr.Value{})
-	}
-
 	elements := make([]attr.Value, 0, len(list))
 	for _, v := range list {
 		elements = append(elements, v.toTerraformObject())
+	}
+
+	// When the API returns restrictions, always reflect them (with their IDs) in
+	// state. This is required for imported resources: their initial state has no
+	// restrictions, so we must reconcile from the API by ID instead of trying to
+	// recreate restrictions that already exist (which causes a 409 Conflict on the
+	// next apply).
+	if len(elements) == 0 {
+		// No restrictions on the API side: preserve the prior null-vs-empty shape so
+		// a never-configured block stays null while an explicitly empty set stays empty.
+		if initialState.IsNull() {
+			return types.SetNull(deploymentRestrictionObjectType)
+		}
+		return types.SetValueMust(deploymentRestrictionObjectType, []attr.Value{})
 	}
 
 	return types.SetValueMust(deploymentRestrictionObjectType, elements)

--- a/qovery/deployment_restriction_model_test.go
+++ b/qovery/deployment_restriction_model_test.go
@@ -1,0 +1,68 @@
+//go:build unit && !integration
+// +build unit,!integration
+
+package qovery
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+
+	qovery "github.com/qovery/qovery-client-go"
+
+	"github.com/qovery/terraform-provider-qovery/internal/domain/deploymentrestriction"
+)
+
+func TestFromDeploymentRestrictionList(t *testing.T) {
+	t.Parallel()
+
+	t.Run("import_returns_api_restrictions_with_ids", func(t *testing.T) {
+		t.Parallel()
+		// On import the prior state has no restrictions (null set) but the API returns
+		// existing ones. They must be reflected in state with their IDs so the next
+		// apply reconciles by ID instead of trying to recreate them (which 409s).
+		id := "restriction-id"
+		apiRestrictions := []deploymentrestriction.ServiceDeploymentRestriction{
+			{
+				Id:    &id,
+				Mode:  qovery.DEPLOYMENTRESTRICTIONMODEENUM_MATCH,
+				Type:  qovery.DEPLOYMENTRESTRICTIONTYPEENUM_PATH,
+				Value: ".Dockerignore",
+			},
+		}
+
+		result := FromDeploymentRestrictionList(types.SetNull(deploymentRestrictionObjectType), apiRestrictions)
+
+		assert.False(t, result.IsNull(), "API restrictions must not be discarded on import")
+		assert.Len(t, result.Elements(), 1)
+
+		var list []DeploymentRestriction
+		assert.False(t, result.ElementsAs(context.Background(), &list, false).HasError())
+		if assert.Len(t, list, 1) {
+			assert.Equal(t, id, list[0].Id.ValueString())
+			assert.Equal(t, "MATCH", list[0].Mode.ValueString())
+			assert.Equal(t, "PATH", list[0].Type.ValueString())
+			assert.Equal(t, ".Dockerignore", list[0].Value.ValueString())
+		}
+	})
+
+	t.Run("no_api_restrictions_and_null_state_returns_null", func(t *testing.T) {
+		t.Parallel()
+		result := FromDeploymentRestrictionList(types.SetNull(deploymentRestrictionObjectType), nil)
+
+		assert.True(t, result.IsNull(), "a never-configured block should stay null")
+	})
+
+	t.Run("no_api_restrictions_and_empty_state_returns_empty", func(t *testing.T) {
+		t.Parallel()
+		emptyState := types.SetValueMust(deploymentRestrictionObjectType, []attr.Value{})
+
+		result := FromDeploymentRestrictionList(emptyState, nil)
+
+		assert.False(t, result.IsNull(), "an explicitly empty set should stay empty, not null")
+		assert.Len(t, result.Elements(), 0)
+	})
+}

--- a/qovery/resource_helm_model.go
+++ b/qovery/resource_helm_model.go
@@ -465,9 +465,17 @@ func HelmSourceFromDomainHelmSource(source helm.Source) HelmSource {
 	}
 }
 
-func HelmPortsFromDomainHelmPorts(ports []helm.Port) *map[string]HelmPort {
+func HelmPortsFromDomainHelmPorts(ports []helm.Port, state *map[string]HelmPort) *map[string]HelmPort {
 	if len(ports) == 0 {
-		return nil
+		// Preserve the prior plan/state shape so an explicitly empty map declared in
+		// the config stays an empty map (and a never-configured/null block stays null).
+		// Returning nil unconditionally flips a config-declared empty map to null and
+		// breaks Terraform's post-apply consistency check.
+		if state == nil {
+			return nil
+		}
+		empty := make(map[string]HelmPort)
+		return &empty
 	}
 
 	portsAsMap := make(map[string]HelmPort, len(ports))
@@ -488,7 +496,7 @@ func HelmPortsFromDomainHelmPorts(ports []helm.Port) *map[string]HelmPort {
 func convertDomainHelmToHelm(ctx context.Context, state Helm, helm *helm.Helm) Helm {
 	source := HelmSourceFromDomainHelmSource(helm.Source)
 	valuesOverride := HelmValuesOverrideFromDomainHelmValuesOverride(ctx, helm.ValuesOverride, state.ValuesOverride)
-	ports := HelmPortsFromDomainHelmPorts(helm.Ports)
+	ports := HelmPortsFromDomainHelmPorts(helm.Ports, state.Ports)
 
 	return Helm{
 		ID:                           FromString(helm.ID.String()),

--- a/qovery/resource_job_model.go
+++ b/qovery/resource_job_model.go
@@ -133,55 +133,70 @@ func (s JobSchedule) toUpsertRequest() job.JobSchedule {
 	}
 }
 
-func JobScheduleFromDomainJobSchedule(s job.JobSchedule) JobSchedule {
+// argumentsFromDomain converts domain arguments to their terraform representation
+// while preserving the prior plan/state null-vs-empty shape when the domain returns
+// no arguments. An empty (non-nil) slice maps to an empty list and a nil slice maps to
+// null. Without this, an empty list declared in the config flips to null after apply
+// (and an omitted/null list would flip to an empty list), breaking Terraform's
+// post-apply consistency check.
+func argumentsFromDomain(domainArgs []string, priorArgs []types.String) []types.String {
+	if len(domainArgs) > 0 {
+		args := make([]types.String, len(domainArgs))
+		for i, arg := range domainArgs {
+			args[i] = FromString(arg)
+		}
+		return args
+	}
+	if priorArgs == nil {
+		return nil
+	}
+	return []types.String{}
+}
+
+func JobScheduleFromDomainJobSchedule(s job.JobSchedule, state *JobSchedule) JobSchedule {
 	var onStart *ExecutionCommand = nil
 	if s.OnStart != nil {
-		var args []types.String
-		if len(s.OnStart.Arguments) > 0 {
-			args = make([]types.String, len(s.OnStart.Arguments))
-			for i, arg := range s.OnStart.Arguments {
-				args[i] = FromString(arg)
-			}
+		var priorArgs []types.String
+		if state != nil && state.OnStart != nil {
+			priorArgs = state.OnStart.Arguments
 		}
 		onStart = &ExecutionCommand{
 			Entrypoint: FromStringPointer(s.OnStart.Entrypoint),
-			Arguments:  args,
+			Arguments:  argumentsFromDomain(s.OnStart.Arguments, priorArgs),
 		}
 	}
 
 	var onStop *ExecutionCommand = nil
 	if s.OnStop != nil {
-		var args []types.String
-		if len(s.OnStop.Arguments) > 0 {
-			args = make([]types.String, len(s.OnStop.Arguments))
-			for i, arg := range s.OnStop.Arguments {
-				args[i] = FromString(arg)
-			}
+		var priorArgs []types.String
+		if state != nil && state.OnStop != nil {
+			priorArgs = state.OnStop.Arguments
 		}
 		onStop = &ExecutionCommand{
 			Entrypoint: FromStringPointer(s.OnStop.Entrypoint),
-			Arguments:  args,
+			Arguments:  argumentsFromDomain(s.OnStop.Arguments, priorArgs),
 		}
 	}
 
 	var onDelete *ExecutionCommand = nil
 	if s.OnDelete != nil {
-		var args []types.String
-		if len(s.OnDelete.Arguments) > 0 {
-			args = make([]types.String, len(s.OnDelete.Arguments))
-			for i, arg := range s.OnDelete.Arguments {
-				args[i] = FromString(arg)
-			}
+		var priorArgs []types.String
+		if state != nil && state.OnDelete != nil {
+			priorArgs = state.OnDelete.Arguments
 		}
 		onDelete = &ExecutionCommand{
 			Entrypoint: FromStringPointer(s.OnDelete.Entrypoint),
-			Arguments:  args,
+			Arguments:  argumentsFromDomain(s.OnDelete.Arguments, priorArgs),
 		}
 	}
 
 	var cronJob *JobScheduleCron = nil
 	if s.CronJob != nil {
-		c := JobScheduleCronFromDomainJobScheduleCron(*s.CronJob)
+		var priorCron *JobScheduleCron
+		if state != nil {
+			priorCron = state.CronJob
+		}
+		c := JobScheduleCronFromDomainJobScheduleCron(*s.CronJob, priorCron)
 		cronJob = &c
 	}
 
@@ -220,20 +235,17 @@ func (s JobScheduleCron) toUpsertRequest() job.JobScheduleCron {
 	}
 }
 
-func JobScheduleCronFromDomainJobScheduleCron(s job.JobScheduleCron) JobScheduleCron {
-	var args []types.String
-	if len(s.Command.Arguments) > 0 {
-		args = make([]types.String, len(s.Command.Arguments))
-		for i, arg := range s.Command.Arguments {
-			args[i] = FromString(arg)
-		}
+func JobScheduleCronFromDomainJobScheduleCron(s job.JobScheduleCron, state *JobScheduleCron) JobScheduleCron {
+	var priorArgs []types.String
+	if state != nil {
+		priorArgs = state.Command.Arguments
 	}
 
 	return JobScheduleCron{
 		Schedule: FromString(s.Schedule),
 		Command: ExecutionCommand{
 			Entrypoint: FromStringPointer(s.Command.Entrypoint),
-			Arguments:  args,
+			Arguments:  argumentsFromDomain(s.Command.Arguments, priorArgs),
 		},
 	}
 }
@@ -411,7 +423,7 @@ func convertDomainJobToJob(ctx context.Context, state Job, job *job.Job) Job {
 	}
 
 	source := JobSourceFromDomainJobSource(job.Source)
-	schedule := JobScheduleFromDomainJobSchedule(job.Schedule)
+	schedule := JobScheduleFromDomainJobSchedule(job.Schedule, state.Schedule)
 
 	healthchecks := convertHealthchecksResponseToDomain(job.HealthChecks)
 	return Job{

--- a/qovery/resource_job_model_test.go
+++ b/qovery/resource_job_model_test.go
@@ -33,7 +33,7 @@ func TestJobScheduleFromDomainJobSchedule(t *testing.T) {
 			},
 		}
 
-		result := JobScheduleFromDomainJobSchedule(schedule)
+		result := JobScheduleFromDomainJobSchedule(schedule, nil)
 
 		assert.NotNil(t, result.OnStart)
 		assert.Nil(t, result.OnStart.Arguments, "nil arguments should stay nil, not become empty slice")
@@ -43,7 +43,7 @@ func TestJobScheduleFromDomainJobSchedule(t *testing.T) {
 		assert.Nil(t, result.OnDelete.Arguments, "nil arguments should stay nil, not become empty slice")
 	})
 
-	t.Run("empty_arguments_stays_nil", func(t *testing.T) {
+	t.Run("empty_arguments_stays_null_when_prior_state_is_null", func(t *testing.T) {
 		t.Parallel()
 		schedule := job.JobSchedule{
 			OnStart: &execution_command.ExecutionCommand{
@@ -60,14 +60,54 @@ func TestJobScheduleFromDomainJobSchedule(t *testing.T) {
 			},
 		}
 
-		result := JobScheduleFromDomainJobSchedule(schedule)
+		// No prior state (e.g. import, or arguments omitted in config): empty domain
+		// arguments must stay null to match the planned/default null value.
+		result := JobScheduleFromDomainJobSchedule(schedule, nil)
 
 		assert.NotNil(t, result.OnStart)
-		assert.Nil(t, result.OnStart.Arguments, "empty arguments should become nil, not empty slice")
+		assert.Nil(t, result.OnStart.Arguments, "empty arguments with null prior state should stay null")
 		assert.NotNil(t, result.OnStop)
-		assert.Nil(t, result.OnStop.Arguments, "empty arguments should become nil, not empty slice")
+		assert.Nil(t, result.OnStop.Arguments, "empty arguments with null prior state should stay null")
 		assert.NotNil(t, result.OnDelete)
-		assert.Nil(t, result.OnDelete.Arguments, "empty arguments should become nil, not empty slice")
+		assert.Nil(t, result.OnDelete.Arguments, "empty arguments with null prior state should stay null")
+	})
+
+	t.Run("empty_arguments_stays_empty_when_prior_state_is_empty", func(t *testing.T) {
+		t.Parallel()
+		schedule := job.JobSchedule{
+			OnStart: &execution_command.ExecutionCommand{
+				Entrypoint: strPtr("/bin/sh"),
+				Arguments:  []string{},
+			},
+			OnStop: &execution_command.ExecutionCommand{
+				Entrypoint: strPtr("/bin/sh"),
+				Arguments:  []string{},
+			},
+			OnDelete: &execution_command.ExecutionCommand{
+				Entrypoint: strPtr("/bin/sh"),
+				Arguments:  []string{},
+			},
+		}
+
+		// Config declared an empty list (prior plan/state holds a non-nil empty slice):
+		// the empty list must be preserved so the post-apply consistency check passes.
+		priorState := &JobSchedule{
+			OnStart:  &ExecutionCommand{Arguments: []types.String{}},
+			OnStop:   &ExecutionCommand{Arguments: []types.String{}},
+			OnDelete: &ExecutionCommand{Arguments: []types.String{}},
+		}
+
+		result := JobScheduleFromDomainJobSchedule(schedule, priorState)
+
+		assert.NotNil(t, result.OnStart)
+		assert.NotNil(t, result.OnStart.Arguments, "empty arguments with empty prior state should stay an empty list, not null")
+		assert.Len(t, result.OnStart.Arguments, 0)
+		assert.NotNil(t, result.OnStop)
+		assert.NotNil(t, result.OnStop.Arguments, "empty arguments with empty prior state should stay an empty list, not null")
+		assert.Len(t, result.OnStop.Arguments, 0)
+		assert.NotNil(t, result.OnDelete)
+		assert.NotNil(t, result.OnDelete.Arguments, "empty arguments with empty prior state should stay an empty list, not null")
+		assert.Len(t, result.OnDelete.Arguments, 0)
 	})
 
 	t.Run("non_empty_arguments_preserved", func(t *testing.T) {
@@ -79,7 +119,7 @@ func TestJobScheduleFromDomainJobSchedule(t *testing.T) {
 			},
 		}
 
-		result := JobScheduleFromDomainJobSchedule(schedule)
+		result := JobScheduleFromDomainJobSchedule(schedule, nil)
 
 		assert.NotNil(t, result.OnStart)
 		assert.Len(t, result.OnStart.Arguments, 2)
@@ -95,7 +135,7 @@ func TestJobScheduleFromDomainJobSchedule(t *testing.T) {
 			OnDelete: nil,
 		}
 
-		result := JobScheduleFromDomainJobSchedule(schedule)
+		result := JobScheduleFromDomainJobSchedule(schedule, nil)
 
 		assert.Nil(t, result.OnStart)
 		assert.Nil(t, result.OnStop)
@@ -111,7 +151,7 @@ func TestJobScheduleFromDomainJobSchedule(t *testing.T) {
 			},
 		}
 
-		result := JobScheduleFromDomainJobSchedule(schedule)
+		result := JobScheduleFromDomainJobSchedule(schedule, nil)
 
 		assert.NotNil(t, result.OnStart)
 		assert.True(t, result.OnStart.Entrypoint.IsNull())
@@ -133,13 +173,13 @@ func TestJobScheduleCronFromDomainJobScheduleCron(t *testing.T) {
 			},
 		}
 
-		result := JobScheduleCronFromDomainJobScheduleCron(cron)
+		result := JobScheduleCronFromDomainJobScheduleCron(cron, nil)
 
 		assert.Equal(t, types.StringValue("0 * * * *"), result.Schedule)
 		assert.Nil(t, result.Command.Arguments, "nil arguments should stay nil, not become empty slice")
 	})
 
-	t.Run("empty_arguments_stays_nil", func(t *testing.T) {
+	t.Run("empty_arguments_stays_null_when_prior_state_is_null", func(t *testing.T) {
 		t.Parallel()
 		cron := job.JobScheduleCron{
 			Schedule: "0 * * * *",
@@ -149,9 +189,29 @@ func TestJobScheduleCronFromDomainJobScheduleCron(t *testing.T) {
 			},
 		}
 
-		result := JobScheduleCronFromDomainJobScheduleCron(cron)
+		result := JobScheduleCronFromDomainJobScheduleCron(cron, nil)
 
-		assert.Nil(t, result.Command.Arguments, "empty arguments should become nil, not empty slice")
+		assert.Nil(t, result.Command.Arguments, "empty arguments with null prior state should stay null")
+	})
+
+	t.Run("empty_arguments_stays_empty_when_prior_state_is_empty", func(t *testing.T) {
+		t.Parallel()
+		cron := job.JobScheduleCron{
+			Schedule: "0 * * * *",
+			Command: execution_command.ExecutionCommand{
+				Entrypoint: strPtr("/bin/sh"),
+				Arguments:  []string{},
+			},
+		}
+
+		priorState := &JobScheduleCron{
+			Command: ExecutionCommand{Arguments: []types.String{}},
+		}
+
+		result := JobScheduleCronFromDomainJobScheduleCron(cron, priorState)
+
+		assert.NotNil(t, result.Command.Arguments, "empty arguments with empty prior state should stay an empty list, not null")
+		assert.Len(t, result.Command.Arguments, 0)
 	})
 
 	t.Run("non_empty_arguments_preserved", func(t *testing.T) {
@@ -164,7 +224,7 @@ func TestJobScheduleCronFromDomainJobScheduleCron(t *testing.T) {
 			},
 		}
 
-		result := JobScheduleCronFromDomainJobScheduleCron(cron)
+		result := JobScheduleCronFromDomainJobScheduleCron(cron, nil)
 
 		assert.Equal(t, types.StringValue("0 * * * *"), result.Schedule)
 		assert.Len(t, result.Command.Arguments, 2)


### PR DESCRIPTION
## Context

Two reproducible bugs in the Qovery Terraform provider (v0.79.0) on **imported** resources, reported by a customer. Both let the change land on Qovery's side but make `terraform apply` exit non-zero, forcing `ignore_changes` workarounds.

Jira: QOV-2044

## Bug 1: `deployment_restrictions` not returned on Read (409 on every apply)

Updating any imported `qovery_application` failed with `409 Conflict - Deployment restriction ... already exists`. `FromDeploymentRestrictionList` short-circuited to an empty set whenever the prior state set had no elements. On import the prior state is a **null** set, so the API restrictions (and their IDs) were discarded, and the next apply tried to recreate restrictions that already exist. Apps created by TF worked because their state already carried the IDs.

Fix: build the set from the API response first and reflect the restrictions (with IDs) in state. The empty/null short-circuit now only applies when the API returns no restrictions, preserving the null-vs-empty distinction.

## Bug 2: "inconsistent result after apply" on empty collections (empty -> null)

`qovery_helm` (`.ports`) and `qovery_job` (`.schedule.on_start|on_stop|on_delete.arguments`, `.schedule.cronjob.command.arguments`) failed the post-apply consistency check when the config declared an empty map/list. The conversion collapsed empty to `null`, mismatching the planned value. These attributes are `Optional`, so the applied value must echo the config exactly: empty stays empty, null stays null.

Fix: preserve the prior plan/state null-vs-empty shape when the domain returns an empty collection (same pattern already used for environment variables). `HelmPortsFromDomainHelmPorts` and the job schedule converters now take the prior state and return an empty collection only when the prior value was empty, null when it was null.

## Tests

- New unit tests for `FromDeploymentRestrictionList` covering the import case (API restrictions reflected with IDs) plus the null and empty edge cases.
- Updated job schedule unit tests: the old assertions encoded the buggy "empty becomes null" behavior; they now assert shape preservation against the prior state.
- Full unit suite green: 1005 tests pass. `go build ./...`, `go vet`, `gofmt` all clean.

## Notes

No OpenAPI spec or client SDK change needed: the API already returns deployment restrictions and the Go client already exposes the endpoint. This is provider-side only.
