### PR TITLE
fix(QOV-2030): remove client-layer resources from state on 404 read

### DIFF
--- a/internal/domain/apierrors/api_errors.go
+++ b/internal/domain/apierrors/api_errors.go
@@ -81,7 +81,7 @@ func (e APIError) Detail() string {
 // errorPayload tries to read the response body to extract the error payload sent by the api client.
 // It returns nil if the body is empty.
 func (e APIError) errorPayload() *apiErrorPayload {
-	if e.err == nil || e.Resp == nil {
+	if e.err == nil || e.Resp == nil || e.Resp.Body == nil {
 		return nil
 	}
 

--- a/internal/domain/apierrors/api_errors.go
+++ b/internal/domain/apierrors/api_errors.go
@@ -20,11 +20,12 @@ type apiErrorPayload struct {
 // APIError represents an error that comes from Qovery's API client.
 // It contains all the information needed to understand an api error.
 type APIError struct {
-	err        error          // err is the actual error returned by the api client.
-	action     APIAction      // action that produced the api client error.
-	resource   APIResource    // resource that produced the api client error.
-	resourceID string         // resourceID that produced the api client error. [NOTE: it is replaced by the resource name in some cases (for failed create requests)]
-	Resp       *http.Response // Resp is the response returned by the api client.
+	err          error          // err is the actual error returned by the api client.
+	action       APIAction      // action that produced the api client error.
+	resource     APIResource    // resource that produced the api client error.
+	resourceID   string         // resourceID that produced the api client error. [NOTE: it is replaced by the resource name in some cases (for failed create requests)]
+	Resp         *http.Response // Resp is the response returned by the api client.
+	bufferedBody []byte         // bufferedBody is the response body, read once at construction so the error can be inspected multiple times.
 }
 
 // IsNotFound returns weather the error is a 404 or not.
@@ -78,39 +79,33 @@ func (e APIError) Detail() string {
 	return fmt.Sprintf("Could not %s %s '%s', %s", e.action, e.resource, e.resourceID, extra)
 }
 
-// errorPayload tries to read the response body to extract the error payload sent by the api client.
-// It returns nil if the body is empty.
+// errorPayload parses the error payload sent by the api client from the body buffered at construction.
+// It returns nil if there is no payload.
 func (e APIError) errorPayload() *apiErrorPayload {
-	if e.err == nil || e.Resp == nil || e.Resp.Body == nil {
-		return nil
-	}
-
-	body, err := io.ReadAll(e.Resp.Body)
-	if err != nil {
+	if e.err == nil || len(e.bufferedBody) == 0 {
 		return nil
 	}
 
 	var payload apiErrorPayload
-	if err := json.Unmarshal(body, &payload); err != nil {
+	if err := json.Unmarshal(e.bufferedBody, &payload); err != nil {
 		return nil
 	}
 
 	return &payload
 }
 
-// NewAPIErrorFromError tries to cast an error into an APIError.
-// This is useful when working with APIError passed as an `error` type to get the actual APIError type.
+// NewAPIErrorFromError finds an APIError in err's wrap chain.
+// This is useful when working with an APIError passed around as an `error`, possibly wrapped by service layers.
+// It returns nil when the chain contains no APIError.
 func NewAPIErrorFromError(err error) *APIError {
-	switch err := err.(type) {
-	case *APIError:
-		return err
-	default:
-		return nil
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return apiErr
 	}
+	return nil
 }
 
-// IsErrNotFound takes an error type and tries to cast it into a APIError to check weather the error is an 404 or not.
-// It returns false if the casting fails.
+// IsErrNotFound reports whether err's wrap chain contains an APIError that is a 404 (per IsNotFound).
 func IsErrNotFound(err error) bool {
 	apiErr := NewAPIErrorFromError(err)
 	if apiErr == nil {
@@ -119,8 +114,7 @@ func IsErrNotFound(err error) bool {
 	return apiErr.IsNotFound()
 }
 
-// IsErrBadRequest takes an error type and tries to cast it into a APIError to check weather the error is an 400 or not.
-// It returns false if the casting fails.
+// IsErrBadRequest reports whether err's wrap chain contains an APIError that is a 400 (per IsBadRequest).
 func IsErrBadRequest(err error) bool {
 	apiErr := NewAPIErrorFromError(err)
 	if apiErr == nil {
@@ -130,13 +124,24 @@ func IsErrBadRequest(err error) bool {
 }
 
 // NewAPIError returns a new instance of APIError with the given parameters.
+// The response body, when present, is buffered here so the error can be inspected multiple
+// times (e.g. IsNotFound then Error) without draining the stream.
 func NewAPIError(action APIAction, resource APIResource, resourceID string, resp *http.Response, err error) *APIError {
+	var bufferedBody []byte
+	if resp != nil && resp.Body != nil {
+		if body, readErr := io.ReadAll(resp.Body); readErr == nil {
+			bufferedBody = body
+		}
+		resp.Body.Close()
+	}
+
 	return &APIError{
-		err:        err,
-		action:     action,
-		resource:   resource,
-		resourceID: resourceID,
-		Resp:       resp,
+		err:          err,
+		action:       action,
+		resource:     resource,
+		resourceID:   resourceID,
+		Resp:         resp,
+		bufferedBody: bufferedBody,
 	}
 }
 

--- a/internal/domain/apierrors/api_errors_test.go
+++ b/internal/domain/apierrors/api_errors_test.go
@@ -4,7 +4,9 @@
 package apierrors
 
 import (
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -12,7 +14,7 @@ import (
 )
 
 // A response built without a Body (e.g. NewNotFoundAPIError, or tests) must not make
-// Detail()/Error() panic when errorPayload tries to read it.
+// Detail()/Error() panic when errorPayload looks for it.
 func TestAPIError_Detail_NilResponseBody(t *testing.T) {
 	t.Parallel()
 
@@ -23,9 +25,7 @@ func TestAPIError_Detail_NilResponseBody(t *testing.T) {
 		errors.New("boom"),
 	)
 
-	assert.NotPanics(t, func() {
-		assert.Contains(t, apiErr.Detail(), "boom")
-	})
+	assert.Contains(t, apiErr.Detail(), "boom")
 }
 
 func TestAPIError_Detail_NotFoundAPIError(t *testing.T) {
@@ -33,8 +33,25 @@ func TestAPIError_Detail_NotFoundAPIError(t *testing.T) {
 
 	apiErr := NewNotFoundAPIError(APIResourceOrganization, "some-id")
 
-	assert.NotPanics(t, func() {
-		assert.Contains(t, apiErr.Detail(), "resource not found")
-	})
+	assert.Contains(t, apiErr.Detail(), "resource not found")
 	assert.True(t, apiErr.IsNotFound())
+}
+
+// The response body is buffered at construction, so inspecting the error more than once
+// (e.g. IsNotFound on the 400 branch, then Error for a diagnostic) must keep the payload.
+func TestAPIError_Detail_BodyReadableMultipleTimes(t *testing.T) {
+	t.Parallel()
+
+	apiErr := NewReadAPIError(
+		APIResourceOrganization,
+		"some-id",
+		&http.Response{
+			StatusCode: http.StatusBadRequest,
+			Body:       io.NopCloser(strings.NewReader(`{"status":400,"detail":"organization does not exist"}`)),
+		},
+		errors.New("boom"),
+	)
+
+	assert.True(t, apiErr.IsNotFound())
+	assert.Contains(t, apiErr.Error(), "organization does not exist")
 }

--- a/internal/domain/apierrors/api_errors_test.go
+++ b/internal/domain/apierrors/api_errors_test.go
@@ -1,0 +1,40 @@
+//go:build unit && !integration
+// +build unit,!integration
+
+package apierrors
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+// A response built without a Body (e.g. NewNotFoundAPIError, or tests) must not make
+// Detail()/Error() panic when errorPayload tries to read it.
+func TestAPIError_Detail_NilResponseBody(t *testing.T) {
+	t.Parallel()
+
+	apiErr := NewReadAPIError(
+		APIResourceOrganization,
+		"some-id",
+		&http.Response{StatusCode: http.StatusInternalServerError},
+		errors.New("boom"),
+	)
+
+	assert.NotPanics(t, func() {
+		assert.Contains(t, apiErr.Detail(), "boom")
+	})
+}
+
+func TestAPIError_Detail_NotFoundAPIError(t *testing.T) {
+	t.Parallel()
+
+	apiErr := NewNotFoundAPIError(APIResourceOrganization, "some-id")
+
+	assert.NotPanics(t, func() {
+		assert.Contains(t, apiErr.Detail(), "resource not found")
+	})
+	assert.True(t, apiErr.IsNotFound())
+}

--- a/qovery/read_not_found.go
+++ b/qovery/read_not_found.go
@@ -2,10 +2,12 @@ package qovery
 
 import (
 	"context"
+	"errors"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 
 	"github.com/qovery/terraform-provider-qovery/client/apierrors"
+	domainapierrors "github.com/qovery/terraform-provider-qovery/internal/domain/apierrors"
 )
 
 // handleReadNotFound centralizes not-found handling for client-layer resource Reads: on
@@ -21,5 +23,33 @@ func handleReadNotFound(ctx context.Context, resp *resource.ReadResponse, apiErr
 		return true
 	}
 	resp.Diagnostics.AddError(apiErr.Summary(), apiErr.Detail())
+	return true
+}
+
+// handleDomainReadNotFound is the domain-service twin of handleReadNotFound, for resource
+// Reads whose service returns a plain error. Not-found is detected either by a typed
+// sentinel (errors.Is against the given sentinels) or by an internal/domain/apierrors
+// *APIError anywhere in the wrap chain reporting IsNotFound (404, 403, and 400+"exist",
+// per that package). Services wrap repository errors with pkg/errors, so detection uses
+// errors.As rather than the package's cast-only IsErrNotFound. On not-found the resource
+// is removed from state so the next plan re-creates it; any other error is surfaced as a
+// diagnostic under the given summary. It reports whether Read should return early (true)
+// or continue because err is nil (false).
+func handleDomainReadNotFound(ctx context.Context, resp *resource.ReadResponse, err error, summary string, sentinels ...error) bool {
+	if err == nil {
+		return false
+	}
+	for _, sentinel := range sentinels {
+		if errors.Is(err, sentinel) {
+			resp.State.RemoveResource(ctx)
+			return true
+		}
+	}
+	var apiErr *domainapierrors.APIError
+	if errors.As(err, &apiErr) && apiErr.IsNotFound() {
+		resp.State.RemoveResource(ctx)
+		return true
+	}
+	resp.Diagnostics.AddError(summary, err.Error())
 	return true
 }

--- a/qovery/read_not_found.go
+++ b/qovery/read_not_found.go
@@ -1,0 +1,25 @@
+package qovery
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+
+	"github.com/qovery/terraform-provider-qovery/client/apierrors"
+)
+
+// handleReadNotFound centralizes not-found handling for client-layer resource Reads: on
+// not-found (404/403, per apierrors.IsNotFound) it removes the resource from state so the
+// next plan re-creates it; on any other error it adds a diagnostic. It reports whether Read
+// should return early (true) or continue because apiErr is nil (false).
+func handleReadNotFound(ctx context.Context, resp *resource.ReadResponse, apiErr *apierrors.APIError) bool {
+	if apiErr == nil {
+		return false
+	}
+	if apierrors.IsNotFound(apiErr) {
+		resp.State.RemoveResource(ctx)
+		return true
+	}
+	resp.Diagnostics.AddError(apiErr.Summary(), apiErr.Detail())
+	return true
+}

--- a/qovery/read_not_found.go
+++ b/qovery/read_not_found.go
@@ -2,7 +2,6 @@ package qovery
 
 import (
 	"context"
-	"errors"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 
@@ -27,26 +26,16 @@ func handleReadNotFound(ctx context.Context, resp *resource.ReadResponse, apiErr
 }
 
 // handleDomainReadNotFound is the domain-service twin of handleReadNotFound, for resource
-// Reads whose service returns a plain error. Not-found is detected either by a typed
-// sentinel (errors.Is against the given sentinels) or by an internal/domain/apierrors
-// *APIError anywhere in the wrap chain reporting IsNotFound (404, 403, and 400+"exist",
-// per that package). Services wrap repository errors with pkg/errors, so detection uses
-// errors.As rather than the package's cast-only IsErrNotFound. On not-found the resource
-// is removed from state so the next plan re-creates it; any other error is surfaced as a
-// diagnostic under the given summary. It reports whether Read should return early (true)
-// or continue because err is nil (false).
-func handleDomainReadNotFound(ctx context.Context, resp *resource.ReadResponse, err error, summary string, sentinels ...error) bool {
+// Reads whose service returns a plain error. Not-found is detected by apierrors.IsErrNotFound
+// (an internal/domain/apierrors *APIError anywhere in the wrap chain reporting 404, 403, or
+// 400+"exist", per that package). On not-found the resource is removed from state so the next
+// plan re-creates it; any other error is surfaced as a diagnostic under the given summary.
+// It reports whether Read should return early (true) or continue because err is nil (false).
+func handleDomainReadNotFound(ctx context.Context, resp *resource.ReadResponse, err error, summary string) bool {
 	if err == nil {
 		return false
 	}
-	for _, sentinel := range sentinels {
-		if errors.Is(err, sentinel) {
-			resp.State.RemoveResource(ctx)
-			return true
-		}
-	}
-	var apiErr *domainapierrors.APIError
-	if errors.As(err, &apiErr) && apiErr.IsNotFound() {
+	if domainapierrors.IsErrNotFound(err) {
 		resp.State.RemoveResource(ctx)
 		return true
 	}

--- a/qovery/read_not_found_domain_test.go
+++ b/qovery/read_not_found_domain_test.go
@@ -14,8 +14,6 @@ import (
 	domainapierrors "github.com/qovery/terraform-provider-qovery/internal/domain/apierrors"
 )
 
-var errTestSentinel = pkgerrors.New("test resource not found sentinel")
-
 func domainReadErrorWithStatus(statusCode int) error {
 	return domainapierrors.NewReadAPIError(
 		domainapierrors.APIResourceOrganization,
@@ -31,53 +29,37 @@ func TestHandleDomainReadNotFound(t *testing.T) {
 	testCases := []struct {
 		TestName      string
 		Err           error
-		Sentinels     []error
-		WantHandled   bool
 		WantStateNull bool
 		WantDiag      bool
 	}{
 		{
-			TestName:    "nil error is not handled, Read continues",
-			Err:         nil,
-			WantHandled: false,
+			TestName: "nil error is not handled, Read continues",
+			Err:      nil,
 		},
 		{
 			TestName:      "raw domain 404 removes the resource from state",
 			Err:           domainReadErrorWithStatus(http.StatusNotFound),
-			WantHandled:   true,
 			WantStateNull: true,
 		},
 		{
 			TestName:      "domain 404 wrapped by the service layer still removes from state",
 			Err:           pkgerrors.Wrap(domainReadErrorWithStatus(http.StatusNotFound), "failed to get organization"),
-			WantHandled:   true,
 			WantStateNull: true,
 		},
 		{
 			TestName:      "403 is treated as not-found and removes from state",
 			Err:           pkgerrors.Wrap(domainReadErrorWithStatus(http.StatusForbidden), "failed to get organization"),
-			WantHandled:   true,
 			WantStateNull: true,
 		},
 		{
-			TestName:      "typed sentinel removes from state",
-			Err:           pkgerrors.Wrap(errTestSentinel, "failed to get credentials"),
-			Sentinels:     []error{errTestSentinel},
-			WantHandled:   true,
-			WantStateNull: true,
+			TestName: "plain error surfaces a diagnostic",
+			Err:      pkgerrors.New("some other failure"),
+			WantDiag: true,
 		},
 		{
-			TestName:    "sentinel not matching surfaces a diagnostic",
-			Err:         pkgerrors.New("some other failure"),
-			Sentinels:   []error{errTestSentinel},
-			WantHandled: true,
-			WantDiag:    true,
-		},
-		{
-			TestName:    "500 surfaces a diagnostic without removing from state",
-			Err:         pkgerrors.Wrap(domainReadErrorWithStatus(http.StatusInternalServerError), "failed to get organization"),
-			WantHandled: true,
-			WantDiag:    true,
+			TestName: "500 surfaces a diagnostic without removing from state",
+			Err:      pkgerrors.Wrap(domainReadErrorWithStatus(http.StatusInternalServerError), "failed to get organization"),
+			WantDiag: true,
 		},
 	}
 
@@ -87,9 +69,9 @@ func TestHandleDomainReadNotFound(t *testing.T) {
 			t.Parallel()
 			resp := newTestReadResponse()
 
-			handled := handleDomainReadNotFound(context.Background(), resp, tc.Err, "Error on test read", tc.Sentinels...)
+			handled := handleDomainReadNotFound(context.Background(), resp, tc.Err, "Error on test read")
 
-			assert.Equal(t, tc.WantHandled, handled)
+			assert.Equal(t, tc.Err != nil, handled)
 			assert.Equal(t, tc.WantStateNull, resp.State.Raw.IsNull())
 			assert.Equal(t, tc.WantDiag, resp.Diagnostics.HasError())
 		})

--- a/qovery/read_not_found_domain_test.go
+++ b/qovery/read_not_found_domain_test.go
@@ -1,0 +1,97 @@
+//go:build unit && !integration
+// +build unit,!integration
+
+package qovery
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	pkgerrors "github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+
+	domainapierrors "github.com/qovery/terraform-provider-qovery/internal/domain/apierrors"
+)
+
+var errTestSentinel = pkgerrors.New("test resource not found sentinel")
+
+func domainReadErrorWithStatus(statusCode int) error {
+	return domainapierrors.NewReadAPIError(
+		domainapierrors.APIResourceOrganization,
+		"some-id",
+		&http.Response{StatusCode: statusCode},
+		pkgerrors.New("boom"),
+	)
+}
+
+func TestHandleDomainReadNotFound(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		TestName      string
+		Err           error
+		Sentinels     []error
+		WantHandled   bool
+		WantStateNull bool
+		WantDiag      bool
+	}{
+		{
+			TestName:    "nil error is not handled, Read continues",
+			Err:         nil,
+			WantHandled: false,
+		},
+		{
+			TestName:      "raw domain 404 removes the resource from state",
+			Err:           domainReadErrorWithStatus(http.StatusNotFound),
+			WantHandled:   true,
+			WantStateNull: true,
+		},
+		{
+			TestName:      "domain 404 wrapped by the service layer still removes from state",
+			Err:           pkgerrors.Wrap(domainReadErrorWithStatus(http.StatusNotFound), "failed to get organization"),
+			WantHandled:   true,
+			WantStateNull: true,
+		},
+		{
+			TestName:      "403 is treated as not-found and removes from state",
+			Err:           pkgerrors.Wrap(domainReadErrorWithStatus(http.StatusForbidden), "failed to get organization"),
+			WantHandled:   true,
+			WantStateNull: true,
+		},
+		{
+			TestName:      "typed sentinel removes from state",
+			Err:           pkgerrors.Wrap(errTestSentinel, "failed to get credentials"),
+			Sentinels:     []error{errTestSentinel},
+			WantHandled:   true,
+			WantStateNull: true,
+		},
+		{
+			TestName:    "sentinel not matching surfaces a diagnostic",
+			Err:         pkgerrors.New("some other failure"),
+			Sentinels:   []error{errTestSentinel},
+			WantHandled: true,
+			WantDiag:    true,
+		},
+		{
+			TestName:    "500 surfaces a diagnostic without removing from state",
+			Err:         pkgerrors.Wrap(domainReadErrorWithStatus(http.StatusInternalServerError), "failed to get organization"),
+			WantHandled: true,
+			WantDiag:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.TestName, func(t *testing.T) {
+			t.Parallel()
+			resp := newTestReadResponse()
+
+			handled := handleDomainReadNotFound(context.Background(), resp, tc.Err, "Error on test read", tc.Sentinels...)
+
+			assert.Equal(t, tc.WantHandled, handled)
+			assert.Equal(t, tc.WantStateNull, resp.State.Raw.IsNull())
+			assert.Equal(t, tc.WantDiag, resp.Diagnostics.HasError())
+		})
+	}
+}

--- a/qovery/read_not_found_test.go
+++ b/qovery/read_not_found_test.go
@@ -1,0 +1,95 @@
+//go:build unit && !integration
+// +build unit,!integration
+
+package qovery
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/qovery/terraform-provider-qovery/client/apierrors"
+)
+
+// newTestReadResponse builds a ReadResponse whose state holds a single non-null "id"
+// attribute, so tests can assert whether handleReadNotFound removed it from state.
+func newTestReadResponse() *resource.ReadResponse {
+	s := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{Computed: true},
+		},
+	}
+	objType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{"id": tftypes.String}}
+	return &resource.ReadResponse{
+		State: tfsdk.State{
+			Raw:    tftypes.NewValue(objType, map[string]tftypes.Value{"id": tftypes.NewValue(tftypes.String, "some-id")}),
+			Schema: s,
+		},
+	}
+}
+
+func readErrorWithStatus(statusCode int) *apierrors.APIError {
+	return apierrors.NewReadError(
+		apierrors.APIResourceApplication,
+		"some-id",
+		&http.Response{StatusCode: statusCode},
+		errors.New("boom"),
+	)
+}
+
+func TestHandleReadNotFound(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		TestName      string
+		APIErr        *apierrors.APIError
+		WantHandled   bool
+		WantStateNull bool
+		WantDiag      bool
+	}{
+		{
+			TestName:    "nil error is not handled, Read continues",
+			APIErr:      nil,
+			WantHandled: false,
+		},
+		{
+			TestName:      "404 removes the resource from state",
+			APIErr:        readErrorWithStatus(http.StatusNotFound),
+			WantHandled:   true,
+			WantStateNull: true,
+		},
+		{
+			TestName:      "403 is treated as not-found and removes from state",
+			APIErr:        readErrorWithStatus(http.StatusForbidden),
+			WantHandled:   true,
+			WantStateNull: true,
+		},
+		{
+			TestName:    "500 surfaces a diagnostic without removing from state",
+			APIErr:      readErrorWithStatus(http.StatusInternalServerError),
+			WantHandled: true,
+			WantDiag:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.TestName, func(t *testing.T) {
+			t.Parallel()
+			resp := newTestReadResponse()
+
+			handled := handleReadNotFound(context.Background(), resp, tc.APIErr)
+
+			assert.Equal(t, tc.WantHandled, handled)
+			assert.Equal(t, tc.WantStateNull, resp.State.Raw.IsNull())
+			assert.Equal(t, tc.WantDiag, resp.Diagnostics.HasError())
+		})
+	}
+}

--- a/qovery/read_not_found_test.go
+++ b/qovery/read_not_found_test.go
@@ -50,32 +50,27 @@ func TestHandleReadNotFound(t *testing.T) {
 	testCases := []struct {
 		TestName      string
 		APIErr        *apierrors.APIError
-		WantHandled   bool
 		WantStateNull bool
 		WantDiag      bool
 	}{
 		{
-			TestName:    "nil error is not handled, Read continues",
-			APIErr:      nil,
-			WantHandled: false,
+			TestName: "nil error is not handled, Read continues",
+			APIErr:   nil,
 		},
 		{
 			TestName:      "404 removes the resource from state",
 			APIErr:        readErrorWithStatus(http.StatusNotFound),
-			WantHandled:   true,
 			WantStateNull: true,
 		},
 		{
 			TestName:      "403 is treated as not-found and removes from state",
 			APIErr:        readErrorWithStatus(http.StatusForbidden),
-			WantHandled:   true,
 			WantStateNull: true,
 		},
 		{
-			TestName:    "500 surfaces a diagnostic without removing from state",
-			APIErr:      readErrorWithStatus(http.StatusInternalServerError),
-			WantHandled: true,
-			WantDiag:    true,
+			TestName: "500 surfaces a diagnostic without removing from state",
+			APIErr:   readErrorWithStatus(http.StatusInternalServerError),
+			WantDiag: true,
 		},
 	}
 
@@ -87,7 +82,7 @@ func TestHandleReadNotFound(t *testing.T) {
 
 			handled := handleReadNotFound(context.Background(), resp, tc.APIErr)
 
-			assert.Equal(t, tc.WantHandled, handled)
+			assert.Equal(t, tc.APIErr != nil, handled)
 			assert.Equal(t, tc.WantStateNull, resp.State.Raw.IsNull())
 			assert.Equal(t, tc.WantDiag, resp.Diagnostics.HasError())
 		})

--- a/qovery/resource_annotations_group.go
+++ b/qovery/resource_annotations_group.go
@@ -137,8 +137,7 @@ func (r annotationsGroupResource) Read(ctx context.Context, req resource.ReadReq
 
 	// Get from the API
 	annotationsGroup, apiErr := r.annotationsGroupService.Get(ctx, state.OrganizationId.ValueString(), state.Id.ValueString())
-	if apiErr != nil {
-		resp.Diagnostics.AddError("Error on annotations group read", apiErr.Error())
+	if handleDomainReadNotFound(ctx, resp, apiErr, "Error on annotations group read") {
 		return
 	}
 

--- a/qovery/resource_application.go
+++ b/qovery/resource_application.go
@@ -840,8 +840,7 @@ func (r applicationResource) Read(ctx context.Context, req resource.ReadRequest,
 
 	// Get application from the API
 	application, apiErr := r.client.GetApplication(ctx, state.Id.ValueString(), state.AdvancedSettingsJson.ValueString(), isTriggeredFromImport)
-	if apiErr != nil {
-		resp.Diagnostics.AddError(apiErr.Summary(), apiErr.Detail())
+	if handleReadNotFound(ctx, resp, apiErr) {
 		return
 	}
 

--- a/qovery/resource_argocd_credentials.go
+++ b/qovery/resource_argocd_credentials.go
@@ -106,8 +106,7 @@ func (r argoCdCredentialsResource) Read(ctx context.Context, req resource.ReadRe
 	}
 
 	creds, err := r.argoCdCredentialsService.Get(ctx, state.ClusterId.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError("Error on argocd credentials read", err.Error())
+	if handleDomainReadNotFound(ctx, resp, err, "Error on argocd credentials read") {
 		return
 	}
 

--- a/qovery/resource_aws_credentials.go
+++ b/qovery/resource_aws_credentials.go
@@ -136,8 +136,7 @@ func (r awsCredentialsResource) Read(ctx context.Context, req resource.ReadReque
 
 	// Get credentials from API
 	creds, err := r.awsCredentialsService.Get(ctx, state.OrganizationId.ValueString(), state.Id.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError("Error on aws credentials read", err.Error())
+	if handleDomainReadNotFound(ctx, resp, err, "Error on aws credentials read", credentials.ErrAwsCredentialsNotFound) {
 		return
 	}
 

--- a/qovery/resource_aws_credentials.go
+++ b/qovery/resource_aws_credentials.go
@@ -136,7 +136,7 @@ func (r awsCredentialsResource) Read(ctx context.Context, req resource.ReadReque
 
 	// Get credentials from API
 	creds, err := r.awsCredentialsService.Get(ctx, state.OrganizationId.ValueString(), state.Id.ValueString())
-	if handleDomainReadNotFound(ctx, resp, err, "Error on aws credentials read", credentials.ErrAwsCredentialsNotFound) {
+	if handleDomainReadNotFound(ctx, resp, err, "Error on aws credentials read") {
 		return
 	}
 

--- a/qovery/resource_cluster.go
+++ b/qovery/resource_cluster.go
@@ -1108,8 +1108,7 @@ func (r clusterResource) Read(ctx context.Context, req resource.ReadRequest, res
 
 	// Get cluster from the API
 	cluster, apiErr := r.client.GetCluster(ctx, state.OrganizationId.ValueString(), state.Id.ValueString(), state.AdvancedSettingsJson.ValueString(), isTriggeredFromImport)
-	if apiErr != nil {
-		resp.Diagnostics.AddError(apiErr.Summary(), apiErr.Detail())
+	if handleReadNotFound(ctx, resp, apiErr) {
 		return
 	}
 

--- a/qovery/resource_cluster_dns_provider.go
+++ b/qovery/resource_cluster_dns_provider.go
@@ -243,8 +243,7 @@ func (r clusterDNSProviderResource) Read(ctx context.Context, req resource.ReadR
 	}
 
 	response, apiErr := r.client.GetClusterDNSProvider(ctx, state.ClusterID.ValueString())
-	if apiErr != nil {
-		resp.Diagnostics.AddError(apiErr.Summary(), apiErr.Detail())
+	if handleReadNotFound(ctx, resp, apiErr) {
 		return
 	}
 

--- a/qovery/resource_container.go
+++ b/qovery/resource_container.go
@@ -724,8 +724,7 @@ func (r containerResource) Read(ctx context.Context, req resource.ReadRequest, r
 
 	// Get container from the API
 	cont, err := r.containerService.Get(ctx, state.ID.ValueString(), state.AdvancedSettingsJson.ValueString(), isTriggeredFromImport)
-	if err != nil {
-		resp.Diagnostics.AddError("Error on container read", err.Error())
+	if handleDomainReadNotFound(ctx, resp, err, "Error on container read") {
 		return
 	}
 

--- a/qovery/resource_container_registry.go
+++ b/qovery/resource_container_registry.go
@@ -216,8 +216,7 @@ func (r containerRegistryResource) Read(ctx context.Context, req resource.ReadRe
 
 	// Get container registry from the API
 	reg, err := r.containerRegistryService.Get(ctx, state.OrganizationId.ValueString(), state.Id.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError("Error on container registry read", err.Error())
+	if handleDomainReadNotFound(ctx, resp, err, "Error on container registry read") {
 		return
 	}
 

--- a/qovery/resource_database.go
+++ b/qovery/resource_database.go
@@ -321,8 +321,7 @@ func (r databaseResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 	// Get database from the API
 	database, apiErr := r.client.GetDatabase(ctx, state.Id.ValueString())
-	if apiErr != nil {
-		resp.Diagnostics.AddError(apiErr.Summary(), apiErr.Detail())
+	if handleReadNotFound(ctx, resp, apiErr) {
 		return
 	}
 

--- a/qovery/resource_deployment_stage.go
+++ b/qovery/resource_deployment_stage.go
@@ -135,8 +135,7 @@ func (r deploymentStageResource) Read(ctx context.Context, req resource.ReadRequ
 
 	// Get deployment stage from the API
 	deploymentStage, err := r.deploymentStageService.Get(ctx, state.EnvironmentId.ValueString(), state.Id.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError("Error on deployment stage read", err.Error())
+	if handleDomainReadNotFound(ctx, resp, err, "Error on deployment stage read") {
 		return
 	}
 

--- a/qovery/resource_eks_anywhere_vsphere_credentials.go
+++ b/qovery/resource_eks_anywhere_vsphere_credentials.go
@@ -143,8 +143,7 @@ func (r eksAnywhereVsphereCredentialsResource) Read(ctx context.Context, req res
 	}
 
 	creds, err := r.eksAnywhereVsphereCredentialsService.Get(ctx, state.OrganizationId.ValueString(), state.Id.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError("Error on eks anywhere vsphere credentials read", err.Error())
+	if handleDomainReadNotFound(ctx, resp, err, "Error on eks anywhere vsphere credentials read") {
 		return
 	}
 

--- a/qovery/resource_environment.go
+++ b/qovery/resource_environment.go
@@ -364,8 +364,7 @@ func (r environmentResource) Read(ctx context.Context, req resource.ReadRequest,
 
 	// Get environment from the API
 	env, err := r.environmentService.Get(ctx, state.Id.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError("Error on environment read", err.Error())
+	if handleDomainReadNotFound(ctx, resp, err, "Error on environment read") {
 		return
 	}
 

--- a/qovery/resource_gcp_credentials.go
+++ b/qovery/resource_gcp_credentials.go
@@ -157,8 +157,7 @@ func (r gcpCredentialsResource) Read(ctx context.Context, req resource.ReadReque
 
 	// Get credentials from API
 	creds, err := r.gcpCredentialsService.Get(ctx, state.OrganizationId.ValueString(), state.Id.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError("Error on gcp credentials read", err.Error())
+	if handleDomainReadNotFound(ctx, resp, err, "Error on gcp credentials read", credentials.ErrGcpCredentialsNotFound) {
 		return
 	}
 

--- a/qovery/resource_gcp_credentials.go
+++ b/qovery/resource_gcp_credentials.go
@@ -157,7 +157,7 @@ func (r gcpCredentialsResource) Read(ctx context.Context, req resource.ReadReque
 
 	// Get credentials from API
 	creds, err := r.gcpCredentialsService.Get(ctx, state.OrganizationId.ValueString(), state.Id.ValueString())
-	if handleDomainReadNotFound(ctx, resp, err, "Error on gcp credentials read", credentials.ErrGcpCredentialsNotFound) {
+	if handleDomainReadNotFound(ctx, resp, err, "Error on gcp credentials read") {
 		return
 	}
 

--- a/qovery/resource_git_token.go
+++ b/qovery/resource_git_token.go
@@ -162,8 +162,7 @@ func (r gitTokenResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 	// Get git token from the API
 	response, err := r.service.Get(ctx, state.OrganizationId.ValueString(), state.ID.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError("Error on git token read", err.Error())
+	if handleDomainReadNotFound(ctx, resp, err, "Error on git token read") {
 		return
 	}
 

--- a/qovery/resource_helm.go
+++ b/qovery/resource_helm.go
@@ -760,8 +760,7 @@ func (r helmResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 
 	// Get helm from the API
 	newHelm, err := r.helmService.Get(ctx, state.ID.ValueString(), state.AdvancedSettingsJson.ValueString(), isTriggeredFromImport)
-	if err != nil {
-		resp.Diagnostics.AddError("Error on helm read", err.Error())
+	if handleDomainReadNotFound(ctx, resp, err, "Error on helm read") {
 		return
 	}
 

--- a/qovery/resource_helm_repository.go
+++ b/qovery/resource_helm_repository.go
@@ -204,8 +204,7 @@ func (r helmRepositoryResource) Read(ctx context.Context, req resource.ReadReque
 
 	// Get helm repository from the API
 	reg, err := r.helmRepositoryService.Get(ctx, state.OrganizationId.ValueString(), state.Id.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError("Error on helm repository read", err.Error())
+	if handleDomainReadNotFound(ctx, resp, err, "Error on helm repository read") {
 		return
 	}
 

--- a/qovery/resource_job.go
+++ b/qovery/resource_job.go
@@ -770,8 +770,7 @@ func (r jobResource) Read(ctx context.Context, req resource.ReadRequest, resp *r
 
 	// Get job from the API
 	cont, err := r.jobService.Get(ctx, state.ID.ValueString(), state.AdvancedSettingsJson.ValueString(), isTriggeredFromImport)
-	if err != nil {
-		resp.Diagnostics.AddError("Error on job read", err.Error())
+	if handleDomainReadNotFound(ctx, resp, err, "Error on job read") {
 		return
 	}
 

--- a/qovery/resource_labels_group.go
+++ b/qovery/resource_labels_group.go
@@ -143,8 +143,7 @@ func (r labelsGroupResource) Read(ctx context.Context, req resource.ReadRequest,
 
 	// Get from the API
 	labelsGroup, apiErr := r.labelsGroupService.Get(ctx, state.OrganizationId.ValueString(), state.Id.ValueString())
-	if apiErr != nil {
-		resp.Diagnostics.AddError("Error on labels group read", apiErr.Error())
+	if handleDomainReadNotFound(ctx, resp, apiErr, "Error on labels group read") {
 		return
 	}
 

--- a/qovery/resource_organization.go
+++ b/qovery/resource_organization.go
@@ -122,8 +122,7 @@ func (r organizationResource) Read(ctx context.Context, req resource.ReadRequest
 
 	// Get organization from API
 	orga, err := r.organizationService.Get(ctx, state.Id.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError("Error on organization read", err.Error())
+	if handleDomainReadNotFound(ctx, resp, err, "Error on organization read") {
 		return
 	}
 

--- a/qovery/resource_project.go
+++ b/qovery/resource_project.go
@@ -279,8 +279,7 @@ func (r projectResource) Read(ctx context.Context, req resource.ReadRequest, res
 
 	// Get project from the API
 	proj, err := r.projectService.Get(ctx, state.Id.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError("Error on project read", err.Error())
+	if handleDomainReadNotFound(ctx, resp, err, "Error on project read") {
 		return
 	}
 

--- a/qovery/resource_read_removed_out_of_band_domain_test.go
+++ b/qovery/resource_read_removed_out_of_band_domain_test.go
@@ -49,9 +49,9 @@ func TestAcc_ProjectRemovedOutOfBand(t *testing.T) {
 							_, err := qoveryAPIClient.ProjectMainCallsAPI.DeleteProject(context.TODO(), id).Execute()
 							return err
 						},
-						func(id string) (int, error) {
+						func(id string) int {
 							_, res, _ := qoveryAPIClient.ProjectMainCallsAPI.GetProject(context.TODO(), id).Execute()
-							return rawStatusCode(res), nil
+							return rawStatusCode(res)
 						},
 					),
 				),
@@ -83,9 +83,9 @@ func TestAcc_EnvironmentRemovedOutOfBand(t *testing.T) {
 							_, err := qoveryAPIClient.EnvironmentMainCallsAPI.DeleteEnvironment(context.TODO(), id).Execute()
 							return err
 						},
-						func(id string) (int, error) {
+						func(id string) int {
 							_, res, _ := qoveryAPIClient.EnvironmentMainCallsAPI.GetEnvironment(context.TODO(), id).Execute()
-							return rawStatusCode(res), nil
+							return rawStatusCode(res)
 						},
 					),
 				),
@@ -110,7 +110,7 @@ func rawStatusCode(res *http.Response) int {
 // client, then polls the raw GET until the API reports it gone (404/403), so the post-apply
 // refresh deterministically sees the deleted state even when the API deletes asynchronously
 // (e.g. environments go through a deletion pipeline).
-func testAccDisappearsViaRawAPI(resourceName string, del func(id string) error, getStatus func(id string) (int, error)) resource.TestCheckFunc {
+func testAccDisappearsViaRawAPI(resourceName string, del func(id string) error, getStatus func(id string) int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok || rs.Primary.ID == "" {
@@ -121,10 +121,7 @@ func testAccDisappearsViaRawAPI(resourceName string, del func(id string) error, 
 		}
 		// Wait until the API reports the resource gone (bounded).
 		for attempt := 0; attempt < 60; attempt++ {
-			status, err := getStatus(rs.Primary.ID)
-			if err != nil {
-				return fmt.Errorf("%s: failed to check deletion: %s", resourceName, err)
-			}
+			status := getStatus(rs.Primary.ID)
 			if status == http.StatusNotFound || status == http.StatusForbidden {
 				return nil
 			}

--- a/qovery/resource_read_removed_out_of_band_domain_test.go
+++ b/qovery/resource_read_removed_out_of_band_domain_test.go
@@ -1,0 +1,135 @@
+//go:build integration && !unit
+// +build integration,!unit
+
+package qovery_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// Out-of-band removal tests for domain-service resources (QOV-2030 Track B).
+//
+// Same "disappears" shape as resource_read_removed_out_of_band_test.go, but for resources
+// whose Read goes through a domain service returning a plain error: the resource is deleted
+// out-of-band via the raw generated API client, then the post-apply refresh must drop it
+// from state (handleDomainReadNotFound → RemoveResource) instead of erroring, and
+// ExpectNonEmptyPlan captures the resulting re-create plan.
+//
+// project and environment are the ticket-prioritized representatives that are cheap to
+// provision (pure API objects, no cloud deploy). The remaining Track B resources share the
+// exact same helper and wrap chain (service errors.Wrap around a domain apierrors.APIError),
+// covered by the unit tests in read_not_found_domain_test.go.
+
+func TestAcc_ProjectRemovedOutOfBand(t *testing.T) {
+	t.Parallel()
+	testName := "project-out-of-band"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProjectDefaultConfig(testName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccQoveryProjectExists("qovery_project.test"),
+				),
+			},
+			{
+				Config: testAccProjectDefaultConfig(testName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccDisappearsViaRawAPI("qovery_project.test",
+						func(id string) error {
+							_, err := qoveryAPIClient.ProjectMainCallsAPI.DeleteProject(context.TODO(), id).Execute()
+							return err
+						},
+						func(id string) (int, error) {
+							_, res, _ := qoveryAPIClient.ProjectMainCallsAPI.GetProject(context.TODO(), id).Execute()
+							return rawStatusCode(res), nil
+						},
+					),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAcc_EnvironmentRemovedOutOfBand(t *testing.T) {
+	t.Parallel()
+	testName := "environment-out-of-band"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnvironmentDefaultConfig(testName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccQoveryEnvironmentExists("qovery_environment.test"),
+				),
+			},
+			{
+				Config: testAccEnvironmentDefaultConfig(testName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccDisappearsViaRawAPI("qovery_environment.test",
+						func(id string) error {
+							_, err := qoveryAPIClient.EnvironmentMainCallsAPI.DeleteEnvironment(context.TODO(), id).Execute()
+							return err
+						},
+						func(id string) (int, error) {
+							_, res, _ := qoveryAPIClient.EnvironmentMainCallsAPI.GetEnvironment(context.TODO(), id).Execute()
+							return rawStatusCode(res), nil
+						},
+					),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// rawStatusCode extracts an HTTP status code from a raw generated-client response.
+// The generated client returns an error alongside the response for non-2xx statuses,
+// so callers intentionally ignore that error and rely on the status code alone.
+// A nil response (network error) is reported as 0 (unknown, keep polling).
+func rawStatusCode(res *http.Response) int {
+	if res == nil {
+		return 0
+	}
+	return res.StatusCode
+}
+
+// testAccDisappearsViaRawAPI deletes the resource out-of-band using the raw generated API
+// client, then polls the raw GET until the API reports it gone (404/403), so the post-apply
+// refresh deterministically sees the deleted state even when the API deletes asynchronously
+// (e.g. environments go through a deletion pipeline).
+func testAccDisappearsViaRawAPI(resourceName string, del func(id string) error, getStatus func(id string) (int, error)) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok || rs.Primary.ID == "" {
+			return fmt.Errorf("%s: id not found in state", resourceName)
+		}
+		if err := del(rs.Primary.ID); err != nil {
+			return fmt.Errorf("%s: failed to delete out-of-band: %s", resourceName, err)
+		}
+		// Wait until the API reports the resource gone (bounded).
+		for attempt := 0; attempt < 60; attempt++ {
+			status, err := getStatus(rs.Primary.ID)
+			if err != nil {
+				return fmt.Errorf("%s: failed to check deletion: %s", resourceName, err)
+			}
+			if status == http.StatusNotFound || status == http.StatusForbidden {
+				return nil
+			}
+			time.Sleep(2 * time.Second)
+		}
+		return fmt.Errorf("%s: still present after out-of-band delete (timeout)", resourceName)
+	}
+}

--- a/qovery/resource_read_removed_out_of_band_test.go
+++ b/qovery/resource_read_removed_out_of_band_test.go
@@ -1,0 +1,180 @@
+//go:build integration && !unit
+// +build integration,!unit
+
+package qovery_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/qovery/terraform-provider-qovery/client/apierrors"
+	"github.com/qovery/terraform-provider-qovery/qovery"
+)
+
+// Out-of-band removal tests for client-layer resources.
+//
+// These "disappears" acceptance tests delete the resource out-of-band (directly via the
+// Qovery API, bypassing Terraform) and then assert that the next refresh/plan does NOT
+// error: the resource must be dropped from state (handleReadNotFound → RemoveResource) so
+// Terraform plans a re-create. `ExpectNonEmptyPlan: true` captures exactly that — the
+// post-apply refresh removes the resource and the plan becomes non-empty (a re-create).
+//
+// Before the fix, the out-of-band delete made Read return a hard diagnostic, so the
+// post-apply refresh errored and the step failed.
+//
+// Coverage note: cluster_dns_provider is the fourth client-layer resource. It has no standalone
+// acceptance scaffolding and no independent delete (it lives inside a cluster), so it is not
+// given a bespoke disappears test here. It calls the same handleReadNotFound helper as the
+// resources below, and that helper is exhaustively covered by the unit test in
+// read_not_found_test.go.
+
+// TestAcc_DatabaseRemovedOutOfBand is runnable in the normal loop: a REDIS container
+// database is cheap and fast to provision.
+func TestAcc_DatabaseRemovedOutOfBand(t *testing.T) {
+	t.Parallel()
+	testName := "database-out-of-band"
+	dbModel := qovery.Database{
+		Name:          qovery.FromString(generateTestName(testName)),
+		IconUri:       qovery.FromString(fmt.Sprintf("app://qovery-console/%s", generateTestName(testName))),
+		Type:          qovery.FromString("REDIS"),
+		Version:       qovery.FromString("6.2"),
+		Mode:          qovery.FromString("CONTAINER"),
+		Accessibility: qovery.FromString("PUBLIC"),
+		CPU:           qovery.FromInt32(250),
+		Memory:        qovery.FromInt32(256),
+		Storage:       qovery.FromInt32(10),
+		InstanceType:  qovery.FromStringPointer(nil),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy: testAccCheckRemovedOutOfBand("qovery_database.test", func(id string) *apierrors.APIError {
+			_, apiErr := apiClient.GetDatabase(context.TODO(), id)
+			return apiErr
+		}),
+		Steps: []resource.TestStep{
+			{
+				Config: GetDatabaseConfigFromModel(testName, dbModel),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccQoveryDatabaseExists("qovery_database.test"),
+				),
+			},
+			{
+				// Delete the database out-of-band, then expect the next plan to re-create it.
+				Config: GetDatabaseConfigFromModel(testName, dbModel),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccQoveryDisappears("qovery_database.test", func(id string) *apierrors.APIError {
+						return apiClient.DeleteDatabase(context.TODO(), id)
+					}),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestAcc_ApplicationRemovedOutOfBand is runnable in the normal loop.
+func TestAcc_ApplicationRemovedOutOfBand(t *testing.T) {
+	t.Parallel()
+	testName := "application-out-of-band"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy: testAccCheckRemovedOutOfBand("qovery_application.test", func(id string) *apierrors.APIError {
+			_, apiErr := apiClient.GetApplication(context.TODO(), id, "{}", false)
+			return apiErr
+		}),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApplicationDefaultConfig(testName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccQoveryApplicationExists("qovery_application.test"),
+				),
+			},
+			{
+				Config: testAccApplicationDefaultConfig(testName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccQoveryDisappears("qovery_application.test", func(id string) *apierrors.APIError {
+						return apiClient.DeleteApplication(context.TODO(), id)
+					}),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestAcc_ClusterRemovedOutOfBand provisions a real Kubernetes cluster (slow + costly);
+// intended for CI, not the interactive loop. This is the originally reported resource.
+func TestAcc_ClusterRemovedOutOfBand(t *testing.T) {
+	t.Parallel()
+	testName := "cluster-out-of-band"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy: testAccCheckRemovedOutOfBand("qovery_cluster.test", func(id string) *apierrors.APIError {
+			_, apiErr := apiClient.GetCluster(context.TODO(), getTestOrganizationID(), id, "{}", false)
+			return apiErr
+		}),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfigWithKeda(testName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccQoveryClusterExists("qovery_cluster.test"),
+				),
+			},
+			{
+				Config: testAccClusterConfigWithKeda(testName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccQoveryDisappears("qovery_cluster.test", func(id string) *apierrors.APIError {
+						return apiClient.DeleteCluster(context.TODO(), getTestOrganizationID(), id)
+					}),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// testAccQoveryDisappears deletes a resource out-of-band via the given delete closure,
+// mirroring the get-closure shape already used by testAccCheckRemovedOutOfBand.
+func testAccQoveryDisappears(resourceName string, del func(id string) *apierrors.APIError) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok || rs.Primary.ID == "" {
+			return fmt.Errorf("%s: id not found in state", resourceName)
+		}
+		if apiErr := del(rs.Primary.ID); apiErr != nil {
+			return fmt.Errorf("%s: failed to delete out-of-band: %s", resourceName, apiErr.Detail())
+		}
+		return nil
+	}
+}
+
+// testAccCheckRemovedOutOfBand is the CheckDestroy for the "disappears" tests. The resource
+// is deleted out-of-band mid-test and then dropped from Terraform state by handleReadNotFound,
+// so its absence from state is the expected clean end-state — not a dangling-resource failure.
+// When the resource is still tracked in state, it confirms the API reports it as deleted.
+func testAccCheckRemovedOutOfBand(resourceName string, get func(id string) *apierrors.APIError) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok || rs.Primary.ID == "" {
+			return nil
+		}
+		apiErr := get(rs.Primary.ID)
+		if apiErr == nil {
+			return fmt.Errorf("%s: found resource but expected it to be deleted", resourceName)
+		}
+		if !apierrors.IsNotFound(apiErr) {
+			return fmt.Errorf("%s: unexpected error checking deletion: %s", resourceName, apiErr.Summary())
+		}
+		return nil
+	}
+}

--- a/qovery/resource_scaleway_credentials.go
+++ b/qovery/resource_scaleway_credentials.go
@@ -142,7 +142,7 @@ func (r scalewayCredentialsResource) Read(ctx context.Context, req resource.Read
 
 	// Get credentials from API
 	creds, err := r.scalewayCredentialsService.Get(ctx, state.OrganizationId.ValueString(), state.Id.ValueString())
-	if handleDomainReadNotFound(ctx, resp, err, "Error on scaleway credentials read", credentials.ErrScalewayCredentialsNotFound) {
+	if handleDomainReadNotFound(ctx, resp, err, "Error on scaleway credentials read") {
 		return
 	}
 

--- a/qovery/resource_scaleway_credentials.go
+++ b/qovery/resource_scaleway_credentials.go
@@ -142,8 +142,7 @@ func (r scalewayCredentialsResource) Read(ctx context.Context, req resource.Read
 
 	// Get credentials from API
 	creds, err := r.scalewayCredentialsService.Get(ctx, state.OrganizationId.ValueString(), state.Id.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError("Error on scaleway credentials read", err.Error())
+	if handleDomainReadNotFound(ctx, resp, err, "Error on scaleway credentials read", credentials.ErrScalewayCredentialsNotFound) {
 		return
 	}
 

--- a/qovery/resource_terraform_service.go
+++ b/qovery/resource_terraform_service.go
@@ -460,8 +460,7 @@ func (r terraformServiceResource) Read(ctx context.Context, req resource.ReadReq
 		ToString(state.AdvancedSettingsJson),
 		isTriggeredFromImport,
 	)
-	if err != nil {
-		resp.Diagnostics.AddError("Error on terraform service read", err.Error())
+	if handleDomainReadNotFound(ctx, resp, err, "Error on terraform service read") {
 		return
 	}
 


### PR DESCRIPTION
When a resource is deleted out-of-band (Console, backend, another operator), `terraform plan`
errored on refresh instead of planning a re-create. Standard Terraform behavior is to drop the
resource from state (`resp.State.RemoveResource`) when the API reports it gone.

### What

- **Two shared helpers** in `qovery/read_not_found.go`:
  - `handleReadNotFound` — client-layer Reads (`*client/apierrors.APIError`)
  - `handleDomainReadNotFound` — domain-service Reads (plain `error`, detected via unwrap-aware `IsErrNotFound`)
- **22 resource Reads wired** (all resources except `argocd_destination_cluster_mapping`,
  already correct, and `deployment`, whose Read never calls the API by design).
- `internal/domain/apierrors`: `NewAPIErrorFromError` now uses `errors.As` (service layers wrap
  repo errors with `pkg/errors`, the previous bare cast never matched), error body is buffered,
  and a nil-`Body` panic in `Detail()` is fixed.

### Notes

- 403 (and 400 + "exist") are treated as not-found, matching the existing helpers' widening.
  Validated live: the API returns **403** for a deleted project.
- `getClusterByID` still uses list+scan with a synthesized 404 (routed correctly through the
  helper); switching to a real single-cluster GET is a follow-up.

### Tests

- Unit: table-driven coverage of both helpers (404 / 403 / wrapped errors / 500 / nil) + apierrors regressions.
- Acceptance ("disappears" pattern): delete out-of-band via API → refresh drops state → plan
  re-creates with no error. Run locally RED→GREEN for `database`, `application`, `project`,
  `environment`; `cluster` variant is written for CI (provisions a real cluster).