### PR TITLE
Prevent existing VPC subnet updates

### DIFF
--- a/qovery/environment_id_replacement_test.go
+++ b/qovery/environment_id_replacement_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
@@ -275,6 +276,104 @@ func TestClusterVpcSubnet_RealChange_ForcesReplacement(t *testing.T) {
 
 	assert.True(t, runVpcSubnetModifiers(t, oldCidr, newCidr),
 		"a genuine vpc_subnet change must force cluster replacement")
+}
+
+// clusterExistingVpcAttribute returns nested features.existing_vpc attribute
+// from cluster resource schema.
+func clusterExistingVpcAttribute(t *testing.T) schema.SingleNestedAttribute {
+	t.Helper()
+
+	var resp resource.SchemaResponse
+	clusterResource{}.Schema(context.Background(), resource.SchemaRequest{}, &resp)
+
+	features, ok := resp.Schema.Attributes["features"].(schema.SingleNestedAttribute)
+	if !ok {
+		t.Fatalf("features not SingleNestedAttribute")
+	}
+	existingVpc, ok := features.Attributes["existing_vpc"].(schema.SingleNestedAttribute)
+	if !ok {
+		t.Fatalf("features.existing_vpc not SingleNestedAttribute")
+	}
+	return existingVpc
+}
+
+func hasRejectKnownListChange(mods []planmodifier.List) bool {
+	ctx := context.Background()
+	for _, m := range mods {
+		if m.Description(ctx) == rejectKnownListChangeDescription {
+			return true
+		}
+	}
+	return false
+}
+
+func runListModifiers(t *testing.T, mods []planmodifier.List, state, plan types.List) (bool, bool) {
+	t.Helper()
+
+	requiresReplace := false
+	hasError := false
+	raw := types.StringValue("non-empty-resource")
+	for _, mod := range mods {
+		resp := &planmodifier.ListResponse{PlanValue: plan}
+		mod.PlanModifyList(context.Background(), planmodifier.ListRequest{
+			State:      buildState(&raw),
+			StateValue: state,
+			Plan:       buildPlan(&raw),
+			PlanValue:  plan,
+		}, resp)
+		requiresReplace = requiresReplace || resp.RequiresReplace
+		hasError = hasError || resp.Diagnostics.HasError()
+	}
+
+	return requiresReplace, hasError
+}
+
+// TestClusterExistingVpcSubnetLists_RejectUpdates guards immutable subnet
+// configuration: API preserves existing_vpc subnets on cluster update, so
+// Terraform must reject the change instead of replacing the cluster.
+func TestClusterExistingVpcSubnetLists_RejectUpdates(t *testing.T) {
+	t.Parallel()
+
+	subnetAttributes := []string{
+		"eks_subnets_zone_a_ids",
+		"eks_subnets_zone_b_ids",
+		"eks_subnets_zone_c_ids",
+		"rds_subnets_zone_a_ids",
+		"rds_subnets_zone_b_ids",
+		"rds_subnets_zone_c_ids",
+		"documentdb_subnets_zone_a_ids",
+		"documentdb_subnets_zone_b_ids",
+		"documentdb_subnets_zone_c_ids",
+		"elasticache_subnets_zone_a_ids",
+		"elasticache_subnets_zone_b_ids",
+		"elasticache_subnets_zone_c_ids",
+		"eks_karpenter_fargate_subnets_zone_a_ids",
+		"eks_karpenter_fargate_subnets_zone_b_ids",
+		"eks_karpenter_fargate_subnets_zone_c_ids",
+	}
+
+	existingVpc := clusterExistingVpcAttribute(t)
+	for _, attrName := range subnetAttributes {
+		attrName := attrName
+		t.Run(attrName, func(t *testing.T) {
+			t.Parallel()
+
+			schemaAttr, ok := existingVpc.Attributes[attrName]
+			require.True(t, ok, "features.existing_vpc.%s missing", attrName)
+
+			listAttr, ok := schemaAttr.(schema.ListAttribute)
+			require.True(t, ok, "features.existing_vpc.%s must ListAttribute", attrName)
+			assert.True(t, hasRejectKnownListChange(listAttr.PlanModifiers),
+				"features.existing_vpc.%s immutable changes must be rejected", attrName)
+
+			stateValue := types.ListValueMust(types.StringType, []attr.Value{types.StringValue("subnet-existing")})
+			planValue := types.ListValueMust(types.StringType, []attr.Value{types.StringValue("subnet-existing"), types.StringValue("subnet-new")})
+			requiresReplace, hasError := runListModifiers(t, listAttr.PlanModifiers, stateValue, planValue)
+
+			assert.False(t, requiresReplace, "features.existing_vpc.%s must not force cluster replacement", attrName)
+			assert.True(t, hasError, "features.existing_vpc.%s immutable changes must produce a plan error", attrName)
+		})
+	}
 }
 
 // ----------------------------------------------------------------------------

--- a/qovery/environment_id_replacement_test.go
+++ b/qovery/environment_id_replacement_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
@@ -276,104 +275,6 @@ func TestClusterVpcSubnet_RealChange_ForcesReplacement(t *testing.T) {
 
 	assert.True(t, runVpcSubnetModifiers(t, oldCidr, newCidr),
 		"a genuine vpc_subnet change must force cluster replacement")
-}
-
-// clusterExistingVpcAttribute returns nested features.existing_vpc attribute
-// from cluster resource schema.
-func clusterExistingVpcAttribute(t *testing.T) schema.SingleNestedAttribute {
-	t.Helper()
-
-	var resp resource.SchemaResponse
-	clusterResource{}.Schema(context.Background(), resource.SchemaRequest{}, &resp)
-
-	features, ok := resp.Schema.Attributes["features"].(schema.SingleNestedAttribute)
-	if !ok {
-		t.Fatalf("features not SingleNestedAttribute")
-	}
-	existingVpc, ok := features.Attributes["existing_vpc"].(schema.SingleNestedAttribute)
-	if !ok {
-		t.Fatalf("features.existing_vpc not SingleNestedAttribute")
-	}
-	return existingVpc
-}
-
-func hasRejectKnownListChange(mods []planmodifier.List) bool {
-	ctx := context.Background()
-	for _, m := range mods {
-		if m.Description(ctx) == rejectKnownListChangeDescription {
-			return true
-		}
-	}
-	return false
-}
-
-func runListModifiers(t *testing.T, mods []planmodifier.List, state, plan types.List) (bool, bool) {
-	t.Helper()
-
-	requiresReplace := false
-	hasError := false
-	raw := types.StringValue("non-empty-resource")
-	for _, mod := range mods {
-		resp := &planmodifier.ListResponse{PlanValue: plan}
-		mod.PlanModifyList(context.Background(), planmodifier.ListRequest{
-			State:      buildState(&raw),
-			StateValue: state,
-			Plan:       buildPlan(&raw),
-			PlanValue:  plan,
-		}, resp)
-		requiresReplace = requiresReplace || resp.RequiresReplace
-		hasError = hasError || resp.Diagnostics.HasError()
-	}
-
-	return requiresReplace, hasError
-}
-
-// TestClusterExistingVpcSubnetLists_RejectUpdates guards immutable subnet
-// configuration: API preserves existing_vpc subnets on cluster update, so
-// Terraform must reject the change instead of replacing the cluster.
-func TestClusterExistingVpcSubnetLists_RejectUpdates(t *testing.T) {
-	t.Parallel()
-
-	subnetAttributes := []string{
-		"eks_subnets_zone_a_ids",
-		"eks_subnets_zone_b_ids",
-		"eks_subnets_zone_c_ids",
-		"rds_subnets_zone_a_ids",
-		"rds_subnets_zone_b_ids",
-		"rds_subnets_zone_c_ids",
-		"documentdb_subnets_zone_a_ids",
-		"documentdb_subnets_zone_b_ids",
-		"documentdb_subnets_zone_c_ids",
-		"elasticache_subnets_zone_a_ids",
-		"elasticache_subnets_zone_b_ids",
-		"elasticache_subnets_zone_c_ids",
-		"eks_karpenter_fargate_subnets_zone_a_ids",
-		"eks_karpenter_fargate_subnets_zone_b_ids",
-		"eks_karpenter_fargate_subnets_zone_c_ids",
-	}
-
-	existingVpc := clusterExistingVpcAttribute(t)
-	for _, attrName := range subnetAttributes {
-		attrName := attrName
-		t.Run(attrName, func(t *testing.T) {
-			t.Parallel()
-
-			schemaAttr, ok := existingVpc.Attributes[attrName]
-			require.True(t, ok, "features.existing_vpc.%s missing", attrName)
-
-			listAttr, ok := schemaAttr.(schema.ListAttribute)
-			require.True(t, ok, "features.existing_vpc.%s must ListAttribute", attrName)
-			assert.True(t, hasRejectKnownListChange(listAttr.PlanModifiers),
-				"features.existing_vpc.%s immutable changes must be rejected", attrName)
-
-			stateValue := types.ListValueMust(types.StringType, []attr.Value{types.StringValue("subnet-existing")})
-			planValue := types.ListValueMust(types.StringType, []attr.Value{types.StringValue("subnet-existing"), types.StringValue("subnet-new")})
-			requiresReplace, hasError := runListModifiers(t, listAttr.PlanModifiers, stateValue, planValue)
-
-			assert.False(t, requiresReplace, "features.existing_vpc.%s must not force cluster replacement", attrName)
-			assert.True(t, hasError, "features.existing_vpc.%s immutable changes must produce a plan error", attrName)
-		})
-	}
 }
 
 // ----------------------------------------------------------------------------

--- a/qovery/plan_modifiers.go
+++ b/qovery/plan_modifiers.go
@@ -2,8 +2,10 @@ package qovery
 
 import (
 	"context"
+	"sort"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -304,52 +306,198 @@ func requiresReplaceIfKnownChangeFunc(_ context.Context, req planmodifier.String
 	resp.RequiresReplace = true
 }
 
-const rejectKnownListChangeDescription = "Rejects known list value changes after creation."
+const rejectExistingVpcChangeDescription = "Rejects any change to the existing VPC configuration after creation: adding or removing the block, or changing any of its attributes."
 
-// rejectKnownListChangeModifier rejects immutable list changes once a prior
-// value exists in state. Unknown planned values are ignored so deferred data
-// sources can resolve before a concrete comparison is possible.
-type rejectKnownListChangeModifier struct{}
+// rejectExistingVpcChangeModifier rejects changes to an immutable existing-VPC
+// block once the cluster exists, without forcing replacement. It guards the
+// whole block at the object level:
+//
+//   - presence: adding or removing the block after creation is rejected. This
+//     must be caught on the object because the framework skips the children's
+//     plan modifiers entirely when the planned block is null (fwserver "null
+//     and unknown values should not have nested schema to modify").
+//   - content: any known child value change is rejected, so attributes added
+//     to the block later are immutable by default with no per-attribute
+//     wiring. Unknown children (deferred data sources, unresolved Computed
+//     values) are skipped. Null is normalized per child type — null≡empty for
+//     lists and strings, null≡false for bools — because the API does not
+//     distinguish those pairs.
+type rejectExistingVpcChangeModifier struct{}
 
-func (m rejectKnownListChangeModifier) Description(_ context.Context) string {
-	return rejectKnownListChangeDescription
+func (m rejectExistingVpcChangeModifier) Description(_ context.Context) string {
+	return rejectExistingVpcChangeDescription
 }
 
-func (m rejectKnownListChangeModifier) MarkdownDescription(_ context.Context) string {
-	return "Rejects known list value changes after creation."
+func (m rejectExistingVpcChangeModifier) MarkdownDescription(_ context.Context) string {
+	return rejectExistingVpcChangeDescription
 }
 
-func (m rejectKnownListChangeModifier) PlanModifyList(_ context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
-	if req.StateValue.IsNull() || req.StateValue.IsUnknown() || req.PlanValue.IsNull() || req.PlanValue.IsUnknown() {
+func (m rejectExistingVpcChangeModifier) PlanModifyObject(_ context.Context, req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse) {
+	// Resource creation: no prior value exists, nothing is immutable yet.
+	if req.State.Raw.IsNull() {
 		return
 	}
 
-	for _, element := range req.StateValue.Elements() {
-		if element.IsUnknown() {
-			return
-		}
+	// Resource destroy: values are planned to null, which must not be mistaken
+	// for a removal. Unreachable on framework v1.19.0 (destroy plans skip plan
+	// modification entirely) but guarded per the framework's own
+	// RequiresReplaceIf convention in case that changes.
+	if req.Plan.Raw.IsNull() {
+		return
 	}
-	for _, element := range req.PlanValue.Elements() {
-		if element.IsUnknown() {
-			return
-		}
-	}
-
-	if req.PlanValue.Equal(req.StateValue) {
+	if req.PlanValue.IsUnknown() {
 		return
 	}
 
-	resp.Diagnostics.AddAttributeError(
-		req.Path,
-		"Cannot update existing VPC subnets",
-		"Existing VPC subnet lists are immutable after cluster creation. Create a new cluster with the desired subnet configuration instead of updating this value.",
+	if req.StateValue.IsNull() != req.PlanValue.IsNull() {
+		addExistingVpcImmutableError(req.Path, &resp.Diagnostics)
+		return
+	}
+	if req.StateValue.IsNull() {
+		return
+	}
+
+	stateAttrs := req.StateValue.Attributes()
+	planAttrs := req.PlanValue.Attributes()
+	names := make([]string, 0, len(planAttrs))
+	for name := range planAttrs {
+		names = append(names, name)
+	}
+	sort.Strings(names) // deterministic diagnostic order
+
+	for _, name := range names {
+		planValue := planAttrs[name]
+		stateValue, ok := stateAttrs[name]
+		// Unknown children are not user-driven changes: a deferred data source
+		// or a sibling Computed modifier (e.g. UseStateForUnknown) resolves
+		// them before the plan is finalized.
+		if !ok || planValue.IsUnknown() {
+			continue
+		}
+
+		changed, reorderOnly := existingVpcAttributeChanged(stateValue, planValue)
+		if !changed {
+			continue
+		}
+		if reorderOnly {
+			// An order-only difference cannot be let through: the planned value
+			// cannot be normalized to the state order (Terraform core rejects
+			// planned values that differ from config on non-Computed attributes),
+			// and applying would produce an inconsistent result because the API
+			// ignores the reorder. It gets a dedicated message so the remediation
+			// is obvious.
+			resp.Diagnostics.AddAttributeError(
+				req.Path.AtName(name),
+				"Existing VPC list order changed",
+				"This list contains the same elements as the Terraform state but in a different order. "+
+					"The Qovery API ignores ordering changes, so applying would produce an inconsistent result. "+
+					"Reorder the values in your configuration to match the Terraform state.",
+			)
+			continue
+		}
+		addExistingVpcImmutableError(req.Path.AtName(name), &resp.Diagnostics)
+	}
+}
+
+// existingVpcAttributeChanged reports whether a child attribute of an
+// existing-VPC block has a user-visible change between state and plan.
+// reorderOnly is true when a list holds the same elements in a different
+// order. Lists with unknown elements are never a change — deferred data
+// sources must resolve before a concrete comparison is possible.
+func existingVpcAttributeChanged(stateValue, planValue attr.Value) (changed bool, reorderOnly bool) {
+	switch plan := planValue.(type) {
+	case types.List:
+		state, ok := stateValue.(types.List)
+		if !ok {
+			break
+		}
+		if plan.Equal(state) {
+			return false, false
+		}
+		for _, element := range plan.Elements() {
+			if element.IsUnknown() {
+				return false, false
+			}
+		}
+		if listIsNullOrEmpty(state) && listIsNullOrEmpty(plan) {
+			return false, false
+		}
+		return true, listsEqualIgnoringOrder(state, plan)
+	case types.String:
+		state, ok := stateValue.(types.String)
+		if ok && stringIsNullOrEmpty(state) && stringIsNullOrEmpty(plan) {
+			return false, false
+		}
+	case types.Bool:
+		state, ok := stateValue.(types.Bool)
+		if ok && boolIsNullOrFalse(state) && boolIsNullOrFalse(plan) {
+			return false, false
+		}
+	}
+	return !planValue.Equal(stateValue), false
+}
+
+// addExistingVpcImmutableError emits the shared diagnostic for immutable
+// existing-VPC attributes (AWS and GCP): the API ignores these changes, so the
+// plan is rejected instead of forcing a cluster replacement.
+func addExistingVpcImmutableError(p path.Path, diags *diag.Diagnostics) {
+	diags.AddAttributeError(
+		p,
+		"Cannot change existing VPC configuration",
+		"The existing VPC configuration is immutable after cluster creation: the Qovery API ignores these changes. "+
+			"To keep this cluster, revert this attribute to match the Terraform state. "+
+			"To use a different VPC configuration, recreate the cluster explicitly, e.g. `terraform destroy -target=<cluster resource>` followed by `terraform apply`. "+
+			"Note that `terraform apply -replace=...` cannot be used here because the plan is rejected before the replacement is applied.",
 	)
 }
 
-// RejectKnownListChange rejects known updates to immutable list attributes after
-// creation without forcing resource replacement.
-func RejectKnownListChange() planmodifier.List {
-	return rejectKnownListChangeModifier{}
+// listIsNullOrEmpty reports whether the list is null or has no elements.
+func listIsNullOrEmpty(v types.List) bool {
+	return v.IsNull() || len(v.Elements()) == 0
+}
+
+// listsEqualIgnoringOrder reports whether two known lists hold the same elements
+// with the same multiplicity, regardless of order.
+func listsEqualIgnoringOrder(a, b types.List) bool {
+	aElements := a.Elements()
+	bElements := b.Elements()
+	if len(aElements) != len(bElements) {
+		return false
+	}
+
+	matched := make([]bool, len(bElements))
+	for _, aElement := range aElements {
+		found := false
+		for i, bElement := range bElements {
+			if !matched[i] && aElement.Equal(bElement) {
+				matched[i] = true
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// RejectExistingVpcChange rejects any change to an immutable existing-VPC
+// block after cluster creation — presence and content — without forcing
+// replacement. Attach it to the block's object attribute; children need no
+// per-attribute modifiers and new attributes are immutable by default.
+func RejectExistingVpcChange() planmodifier.Object {
+	return rejectExistingVpcChangeModifier{}
+}
+
+// stringIsNullOrEmpty reports whether the string is null or empty.
+func stringIsNullOrEmpty(v types.String) bool {
+	return v.IsNull() || v.ValueString() == ""
+}
+
+// boolIsNullOrFalse reports whether the bool is null or false.
+func boolIsNullOrFalse(v types.Bool) bool {
+	return v.IsNull() || !v.ValueBool()
 }
 
 // RequiresReplaceIfKnownChangeTreatingEmptyAs behaves like RequiresReplaceIfKnownChange

--- a/qovery/plan_modifiers.go
+++ b/qovery/plan_modifiers.go
@@ -304,6 +304,54 @@ func requiresReplaceIfKnownChangeFunc(_ context.Context, req planmodifier.String
 	resp.RequiresReplace = true
 }
 
+const rejectKnownListChangeDescription = "Rejects known list value changes after creation."
+
+// rejectKnownListChangeModifier rejects immutable list changes once a prior
+// value exists in state. Unknown planned values are ignored so deferred data
+// sources can resolve before a concrete comparison is possible.
+type rejectKnownListChangeModifier struct{}
+
+func (m rejectKnownListChangeModifier) Description(_ context.Context) string {
+	return rejectKnownListChangeDescription
+}
+
+func (m rejectKnownListChangeModifier) MarkdownDescription(_ context.Context) string {
+	return "Rejects known list value changes after creation."
+}
+
+func (m rejectKnownListChangeModifier) PlanModifyList(_ context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
+	if req.StateValue.IsNull() || req.StateValue.IsUnknown() || req.PlanValue.IsNull() || req.PlanValue.IsUnknown() {
+		return
+	}
+
+	for _, element := range req.StateValue.Elements() {
+		if element.IsUnknown() {
+			return
+		}
+	}
+	for _, element := range req.PlanValue.Elements() {
+		if element.IsUnknown() {
+			return
+		}
+	}
+
+	if req.PlanValue.Equal(req.StateValue) {
+		return
+	}
+
+	resp.Diagnostics.AddAttributeError(
+		req.Path,
+		"Cannot update existing VPC subnets",
+		"Existing VPC subnet lists are immutable after cluster creation. Create a new cluster with the desired subnet configuration instead of updating this value.",
+	)
+}
+
+// RejectKnownListChange rejects known updates to immutable list attributes after
+// creation without forcing resource replacement.
+func RejectKnownListChange() planmodifier.List {
+	return rejectKnownListChangeModifier{}
+}
+
 // RequiresReplaceIfKnownChangeTreatingEmptyAs behaves like RequiresReplaceIfKnownChange
 // but treats an empty-string value as equal to defaultValue when comparing state and
 // plan. Use it on an Optional+Computed string attribute whose schema Default is

--- a/qovery/plan_modifiers_test.go
+++ b/qovery/plan_modifiers_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -14,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // --- SmartAllowApiOverride tests ---
@@ -558,4 +561,152 @@ func TestUseStateUnlessPortsChange_Description(t *testing.T) {
 
 	assert.NotEmpty(t, modifier.Description(context.Background()))
 	assert.NotEmpty(t, modifier.MarkdownDescription(context.Background()))
+}
+
+// --- RejectExistingVpcChange tests ---
+
+// existingVpcTestAttrTypes mixes the three child types found in the real
+// existing-VPC blocks so one object exercises every comparison branch.
+var existingVpcTestAttrTypes = map[string]attr.Type{
+	"vpc_id":  types.StringType,
+	"subnets": types.ListType{ElemType: types.StringType},
+	"private": types.BoolType,
+}
+
+func existingVpcObject(vpcID types.String, subnets types.List, private types.Bool) types.Object {
+	return types.ObjectValueMust(existingVpcTestAttrTypes, map[string]attr.Value{
+		"vpc_id":  vpcID,
+		"subnets": subnets,
+		"private": private,
+	})
+}
+
+// TestRejectExistingVpcChange_Behavior exercises the block-level modifier
+// semantics: presence changes and known child value changes after creation are
+// rejected without forcing replacement, while creation, no-ops, per-type null
+// equivalences (null≡empty list/string, null≡false), and unknown (deferred)
+// values are allowed.
+func TestRejectExistingVpcChange_Behavior(t *testing.T) {
+	t.Parallel()
+
+	subnetA := types.ListValueMust(types.StringType, []attr.Value{types.StringValue("subnet-a")})
+	subnetAB := types.ListValueMust(types.StringType, []attr.Value{types.StringValue("subnet-a"), types.StringValue("subnet-b")})
+	subnetBA := types.ListValueMust(types.StringType, []attr.Value{types.StringValue("subnet-b"), types.StringValue("subnet-a")})
+	subnetAA := types.ListValueMust(types.StringType, []attr.Value{types.StringValue("subnet-a"), types.StringValue("subnet-a")})
+	emptyList := types.ListValueMust(types.StringType, []attr.Value{})
+	nullList := types.ListNull(types.StringType)
+	withUnknownElement := types.ListValueMust(types.StringType, []attr.Value{types.StringValue("subnet-a"), types.StringUnknown()})
+
+	vpcA := types.StringValue("vpc-a")
+	base := existingVpcObject(vpcA, subnetA, types.BoolValue(true))
+	nullObject := types.ObjectNull(existingVpcTestAttrTypes)
+
+	raw := types.StringValue("non-empty-resource")
+	existingState := buildState(&raw)
+	updatePlan := buildPlan(&raw)
+
+	testCases := []struct {
+		TestName    string
+		State       tfsdk.State
+		Plan        tfsdk.Plan
+		StateValue  types.Object
+		PlanValue   types.Object
+		ExpectError bool
+	}{
+		{"create_allows_initial_block", buildState(nil), updatePlan, nullObject, base, false},
+		{"destroy_plan_skipped", existingState, buildPlan(nil), base, nullObject, false},
+		{"unchanged_allowed", existingState, updatePlan, base, base, false},
+		{"both_null_allowed", existingState, updatePlan, nullObject, nullObject, false},
+		{"unknown_plan_skipped", existingState, updatePlan, base, types.ObjectUnknown(existingVpcTestAttrTypes), false},
+		{"removal_rejected", existingState, updatePlan, base, nullObject, true},
+		{"addition_after_creation_rejected", existingState, updatePlan, nullObject, base, true},
+		{"unknown_child_skipped", existingState, updatePlan, base,
+			existingVpcObject(types.StringUnknown(), subnetA, types.BoolValue(true)), false},
+		{"string_change_rejected", existingState, updatePlan, base,
+			existingVpcObject(types.StringValue("vpc-b"), subnetA, types.BoolValue(true)), true},
+		{"string_cleared_after_creation_rejected", existingState, updatePlan, base,
+			existingVpcObject(types.StringNull(), subnetA, types.BoolValue(true)), true},
+		{"string_null_and_empty_equivalent", existingState, updatePlan,
+			existingVpcObject(types.StringNull(), subnetA, types.BoolValue(true)),
+			existingVpcObject(types.StringValue(""), subnetA, types.BoolValue(true)), false},
+		{"bool_change_rejected", existingState, updatePlan, base,
+			existingVpcObject(vpcA, subnetA, types.BoolValue(false)), true},
+		{"bool_set_true_after_creation_rejected", existingState, updatePlan,
+			existingVpcObject(vpcA, subnetA, types.BoolNull()),
+			existingVpcObject(vpcA, subnetA, types.BoolValue(true)), true},
+		{"bool_null_and_false_equivalent", existingState, updatePlan,
+			existingVpcObject(vpcA, subnetA, types.BoolNull()),
+			existingVpcObject(vpcA, subnetA, types.BoolValue(false)), false},
+		{"list_element_added_rejected", existingState, updatePlan, base,
+			existingVpcObject(vpcA, subnetAB, types.BoolValue(true)), true},
+		{"list_multiplicity_change_rejected", existingState, updatePlan,
+			existingVpcObject(vpcA, subnetAB, types.BoolValue(true)),
+			existingVpcObject(vpcA, subnetAA, types.BoolValue(true)), true},
+		{"list_removed_after_creation_rejected", existingState, updatePlan, base,
+			existingVpcObject(vpcA, nullList, types.BoolValue(true)), true},
+		{"list_reorder_rejected", existingState, updatePlan,
+			existingVpcObject(vpcA, subnetAB, types.BoolValue(true)),
+			existingVpcObject(vpcA, subnetBA, types.BoolValue(true)), true},
+		{"list_null_and_empty_equivalent", existingState, updatePlan,
+			existingVpcObject(vpcA, nullList, types.BoolValue(true)),
+			existingVpcObject(vpcA, emptyList, types.BoolValue(true)), false},
+		{"list_unknown_element_skipped", existingState, updatePlan, base,
+			existingVpcObject(vpcA, withUnknownElement, types.BoolValue(true)), false},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.TestName, func(t *testing.T) {
+			t.Parallel()
+
+			resp := &planmodifier.ObjectResponse{PlanValue: tc.PlanValue}
+			RejectExistingVpcChange().PlanModifyObject(context.Background(), planmodifier.ObjectRequest{
+				Path:       path.Root("features").AtName("existing_vpc"),
+				State:      tc.State,
+				StateValue: tc.StateValue,
+				Plan:       tc.Plan,
+				PlanValue:  tc.PlanValue,
+			}, resp)
+
+			assert.False(t, resp.RequiresReplace, "modifier must never force replacement")
+			assert.Equal(t, tc.ExpectError, resp.Diagnostics.HasError(),
+				"unexpected diagnostics outcome: %v", resp.Diagnostics)
+		})
+	}
+}
+
+// TestRejectExistingVpcChange_DiagnosticDetails asserts that a child change is
+// reported on the changed child's path, and that an order-only list difference
+// gets the reorder-specific diagnostic (which tells the user to match the
+// state order) rather than the generic immutability error.
+func TestRejectExistingVpcChange_DiagnosticDetails(t *testing.T) {
+	t.Parallel()
+
+	subnetAB := types.ListValueMust(types.StringType, []attr.Value{types.StringValue("subnet-a"), types.StringValue("subnet-b")})
+	subnetBA := types.ListValueMust(types.StringType, []attr.Value{types.StringValue("subnet-b"), types.StringValue("subnet-a")})
+	vpcA := types.StringValue("vpc-a")
+	raw := types.StringValue("non-empty-resource")
+	blockPath := path.Root("features").AtName("existing_vpc")
+
+	stateValue := existingVpcObject(vpcA, subnetAB, types.BoolValue(true))
+	planValue := existingVpcObject(vpcA, subnetBA, types.BoolValue(true))
+
+	resp := &planmodifier.ObjectResponse{PlanValue: planValue}
+	RejectExistingVpcChange().PlanModifyObject(context.Background(), planmodifier.ObjectRequest{
+		Path:       blockPath,
+		State:      buildState(&raw),
+		StateValue: stateValue,
+		Plan:       buildPlan(&raw),
+		PlanValue:  planValue,
+	}, resp)
+
+	require.Len(t, resp.Diagnostics.Errors(), 1, "exactly the changed child must be reported")
+	diagErr := resp.Diagnostics.Errors()[0]
+	assert.Equal(t, "Existing VPC list order changed", diagErr.Summary(),
+		"reorder must get the order-specific diagnostic, not the generic immutability error")
+
+	withPath, ok := diagErr.(diag.DiagnosticWithPath)
+	require.True(t, ok, "diagnostic must carry an attribute path")
+	assert.True(t, blockPath.AtName("subnets").Equal(withPath.Path()),
+		"diagnostic must point at the changed child attribute, got %s", withPath.Path())
 }

--- a/qovery/resource_cluster.go
+++ b/qovery/resource_cluster.go
@@ -319,8 +319,11 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						},
 					},
 					"existing_vpc": schema.SingleNestedAttribute{
-						Optional:    true,
-						Computed:    false,
+						Optional: true,
+						Computed: false,
+						PlanModifiers: []planmodifier.Object{
+							RejectExistingVpcChange(),
+						},
 						Description: "Network configuration if you want to install qovery on an existing VPC",
 						MarkdownDescription: "AWS existing VPC configuration. Use this block to deploy the Qovery cluster into an existing AWS VPC instead of creating a new one. " +
 							"All EKS subnets are required, while database and cache subnets are optional.\n\n" +
@@ -338,9 +341,6 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Required:            true,
 								Computed:            false,
-								PlanModifiers: []planmodifier.List{
-									RejectKnownListChange(),
-								},
 							},
 							"eks_subnets_zone_b_ids": schema.ListAttribute{
 								Description:         "Ids of the subnets for EKS zone b. Must have map_public_ip_on_launch set to true",
@@ -348,9 +348,6 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Required:            true,
 								Computed:            false,
-								PlanModifiers: []planmodifier.List{
-									RejectKnownListChange(),
-								},
 							},
 							"eks_subnets_zone_c_ids": schema.ListAttribute{
 								Description:         "Ids of the subnets for EKS zone c. Must have map_public_ip_on_launch set to true",
@@ -358,9 +355,6 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Required:            true,
 								Computed:            false,
-								PlanModifiers: []planmodifier.List{
-									RejectKnownListChange(),
-								},
 							},
 							"rds_subnets_zone_a_ids": schema.ListAttribute{
 								Description:         "Ids of the subnets for RDS",
@@ -368,9 +362,6 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Optional:            true,
 								Computed:            true,
-								PlanModifiers: []planmodifier.List{
-									RejectKnownListChange(),
-								},
 							},
 							"rds_subnets_zone_b_ids": schema.ListAttribute{
 								Description:         "Ids of the subnets for RDS",
@@ -378,9 +369,6 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Optional:            true,
 								Computed:            true,
-								PlanModifiers: []planmodifier.List{
-									RejectKnownListChange(),
-								},
 							},
 							"rds_subnets_zone_c_ids": schema.ListAttribute{
 								Description:         "Ids of the subnets for RDS",
@@ -388,9 +376,6 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Optional:            true,
 								Computed:            true,
-								PlanModifiers: []planmodifier.List{
-									RejectKnownListChange(),
-								},
 							},
 							"documentdb_subnets_zone_a_ids": schema.ListAttribute{
 								Description:         "Ids of the subnets for document db",
@@ -398,9 +383,6 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Optional:            true,
 								Computed:            true,
-								PlanModifiers: []planmodifier.List{
-									RejectKnownListChange(),
-								},
 							},
 							"documentdb_subnets_zone_b_ids": schema.ListAttribute{
 								Description:         "Ids of the subnets for document db",
@@ -408,9 +390,6 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Optional:            true,
 								Computed:            true,
-								PlanModifiers: []planmodifier.List{
-									RejectKnownListChange(),
-								},
 							},
 							"documentdb_subnets_zone_c_ids": schema.ListAttribute{
 								Description:         "Ids of the subnets for document db",
@@ -418,9 +397,6 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Optional:            true,
 								Computed:            true,
-								PlanModifiers: []planmodifier.List{
-									RejectKnownListChange(),
-								},
 							},
 							"elasticache_subnets_zone_a_ids": schema.ListAttribute{
 								Description:         "Ids of the subnets for elasticache",
@@ -428,9 +404,6 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Optional:            true,
 								Computed:            true,
-								PlanModifiers: []planmodifier.List{
-									RejectKnownListChange(),
-								},
 							},
 							"elasticache_subnets_zone_b_ids": schema.ListAttribute{
 								Description:         "Ids of the subnets for elasticache",
@@ -438,9 +411,6 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Optional:            true,
 								Computed:            true,
-								PlanModifiers: []planmodifier.List{
-									RejectKnownListChange(),
-								},
 							},
 							"elasticache_subnets_zone_c_ids": schema.ListAttribute{
 								Description:         "Ids of the subnets for elasticache",
@@ -448,9 +418,6 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Optional:            true,
 								Computed:            true,
-								PlanModifiers: []planmodifier.List{
-									RejectKnownListChange(),
-								},
 							},
 							"eks_karpenter_fargate_subnets_zone_a_ids": schema.ListAttribute{
 								Description:         "Ids of the subnets for EKS fargate zone a. Must have to be private and connected to internet through a NAT Gateway",
@@ -458,9 +425,6 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Optional:            true,
 								Computed:            false,
-								PlanModifiers: []planmodifier.List{
-									RejectKnownListChange(),
-								},
 							},
 							"eks_karpenter_fargate_subnets_zone_b_ids": schema.ListAttribute{
 								Description:         "Ids of the subnets for EKS fargate zone b. Must have to be private and connected to internet through a NAT Gateway",
@@ -468,9 +432,6 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Optional:            true,
 								Computed:            false,
-								PlanModifiers: []planmodifier.List{
-									RejectKnownListChange(),
-								},
 							},
 							"eks_karpenter_fargate_subnets_zone_c_ids": schema.ListAttribute{
 								Description:         "Ids of the subnets for EKS fargate zone c. Must have to be private and connected to internet through a NAT Gateway",
@@ -478,9 +439,6 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Optional:            true,
 								Computed:            false,
-								PlanModifiers: []planmodifier.List{
-									RejectKnownListChange(),
-								},
 							},
 							"eks_create_nodes_in_private_subnet": schema.BoolAttribute{
 								Description:         "Whether to create EKS nodes in private subnet",
@@ -491,8 +449,11 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						},
 					},
 					"gcp_existing_vpc": schema.SingleNestedAttribute{
-						Optional:    true,
-						Computed:    false,
+						Optional: true,
+						Computed: false,
+						PlanModifiers: []planmodifier.Object{
+							RejectExistingVpcChange(),
+						},
 						Description: "Network configuration if you want to install qovery on an existing GCP VPC",
 						MarkdownDescription: "GCP existing VPC configuration. Use this block to deploy the Qovery GKE cluster into an existing Google Cloud VPC network instead of creating a new one.\n\n" +
 							"~> **Warning:** This configuration cannot be changed after cluster creation.",

--- a/qovery/resource_cluster.go
+++ b/qovery/resource_cluster.go
@@ -338,6 +338,9 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Required:            true,
 								Computed:            false,
+								PlanModifiers: []planmodifier.List{
+									RejectKnownListChange(),
+								},
 							},
 							"eks_subnets_zone_b_ids": schema.ListAttribute{
 								Description:         "Ids of the subnets for EKS zone b. Must have map_public_ip_on_launch set to true",
@@ -345,6 +348,9 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Required:            true,
 								Computed:            false,
+								PlanModifiers: []planmodifier.List{
+									RejectKnownListChange(),
+								},
 							},
 							"eks_subnets_zone_c_ids": schema.ListAttribute{
 								Description:         "Ids of the subnets for EKS zone c. Must have map_public_ip_on_launch set to true",
@@ -352,6 +358,9 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Required:            true,
 								Computed:            false,
+								PlanModifiers: []planmodifier.List{
+									RejectKnownListChange(),
+								},
 							},
 							"rds_subnets_zone_a_ids": schema.ListAttribute{
 								Description:         "Ids of the subnets for RDS",
@@ -359,6 +368,9 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Optional:            true,
 								Computed:            true,
+								PlanModifiers: []planmodifier.List{
+									RejectKnownListChange(),
+								},
 							},
 							"rds_subnets_zone_b_ids": schema.ListAttribute{
 								Description:         "Ids of the subnets for RDS",
@@ -366,6 +378,9 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Optional:            true,
 								Computed:            true,
+								PlanModifiers: []planmodifier.List{
+									RejectKnownListChange(),
+								},
 							},
 							"rds_subnets_zone_c_ids": schema.ListAttribute{
 								Description:         "Ids of the subnets for RDS",
@@ -373,6 +388,9 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Optional:            true,
 								Computed:            true,
+								PlanModifiers: []planmodifier.List{
+									RejectKnownListChange(),
+								},
 							},
 							"documentdb_subnets_zone_a_ids": schema.ListAttribute{
 								Description:         "Ids of the subnets for document db",
@@ -380,6 +398,9 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Optional:            true,
 								Computed:            true,
+								PlanModifiers: []planmodifier.List{
+									RejectKnownListChange(),
+								},
 							},
 							"documentdb_subnets_zone_b_ids": schema.ListAttribute{
 								Description:         "Ids of the subnets for document db",
@@ -387,6 +408,9 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Optional:            true,
 								Computed:            true,
+								PlanModifiers: []planmodifier.List{
+									RejectKnownListChange(),
+								},
 							},
 							"documentdb_subnets_zone_c_ids": schema.ListAttribute{
 								Description:         "Ids of the subnets for document db",
@@ -394,6 +418,9 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Optional:            true,
 								Computed:            true,
+								PlanModifiers: []planmodifier.List{
+									RejectKnownListChange(),
+								},
 							},
 							"elasticache_subnets_zone_a_ids": schema.ListAttribute{
 								Description:         "Ids of the subnets for elasticache",
@@ -401,6 +428,9 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Optional:            true,
 								Computed:            true,
+								PlanModifiers: []planmodifier.List{
+									RejectKnownListChange(),
+								},
 							},
 							"elasticache_subnets_zone_b_ids": schema.ListAttribute{
 								Description:         "Ids of the subnets for elasticache",
@@ -408,6 +438,9 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Optional:            true,
 								Computed:            true,
+								PlanModifiers: []planmodifier.List{
+									RejectKnownListChange(),
+								},
 							},
 							"elasticache_subnets_zone_c_ids": schema.ListAttribute{
 								Description:         "Ids of the subnets for elasticache",
@@ -415,6 +448,9 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Optional:            true,
 								Computed:            true,
+								PlanModifiers: []planmodifier.List{
+									RejectKnownListChange(),
+								},
 							},
 							"eks_karpenter_fargate_subnets_zone_a_ids": schema.ListAttribute{
 								Description:         "Ids of the subnets for EKS fargate zone a. Must have to be private and connected to internet through a NAT Gateway",
@@ -422,6 +458,9 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Optional:            true,
 								Computed:            false,
+								PlanModifiers: []planmodifier.List{
+									RejectKnownListChange(),
+								},
 							},
 							"eks_karpenter_fargate_subnets_zone_b_ids": schema.ListAttribute{
 								Description:         "Ids of the subnets for EKS fargate zone b. Must have to be private and connected to internet through a NAT Gateway",
@@ -429,6 +468,9 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Optional:            true,
 								Computed:            false,
+								PlanModifiers: []planmodifier.List{
+									RejectKnownListChange(),
+								},
 							},
 							"eks_karpenter_fargate_subnets_zone_c_ids": schema.ListAttribute{
 								Description:         "Ids of the subnets for EKS fargate zone c. Must have to be private and connected to internet through a NAT Gateway",
@@ -436,6 +478,9 @@ func (r clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								ElementType:         types.StringType,
 								Optional:            true,
 								Computed:            false,
+								PlanModifiers: []planmodifier.List{
+									RejectKnownListChange(),
+								},
 							},
 							"eks_create_nodes_in_private_subnet": schema.BoolAttribute{
 								Description:         "Whether to create EKS nodes in private subnet",

--- a/qovery/resource_cluster_existing_vpc_test.go
+++ b/qovery/resource_cluster_existing_vpc_test.go
@@ -1,0 +1,95 @@
+//go:build unit && !integration
+// +build unit,!integration
+
+// Schema-wiring tests for the immutable existing-VPC blocks of qovery_cluster.
+// Modifier semantics are covered in plan_modifiers_test.go
+// (TestRejectExistingVpcChange_*); these tests only guard that both blocks
+// carry the block-level modifier and that it fires through the wired schema.
+package qovery
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// clusterFeaturesNestedAttribute returns the named nested block under the
+// cluster resource's features attribute.
+func clusterFeaturesNestedAttribute(t *testing.T, name string) schema.SingleNestedAttribute {
+	t.Helper()
+
+	var resp resource.SchemaResponse
+	clusterResource{}.Schema(context.Background(), resource.SchemaRequest{}, &resp)
+
+	features, ok := resp.Schema.Attributes["features"].(schema.SingleNestedAttribute)
+	require.True(t, ok, "features must be a SingleNestedAttribute")
+	block, ok := features.Attributes[name].(schema.SingleNestedAttribute)
+	require.True(t, ok, "features.%s must be a SingleNestedAttribute", name)
+	return block
+}
+
+// TestClusterExistingVpcBlocks_RejectImmutableChanges guards both existing-VPC
+// blocks: the API ignores changes to them after cluster creation, so Terraform
+// must reject any change — removal of the block or a child value change — with
+// a plan error instead of replacing the cluster. Because the guard is wired at
+// the object level, every child attribute (including ones added later) is
+// immutable by default; there is no per-attribute wiring to forget.
+func TestClusterExistingVpcBlocks_RejectImmutableChanges(t *testing.T) {
+	t.Parallel()
+
+	for _, blockName := range []string{"existing_vpc", "gcp_existing_vpc"} {
+		blockName := blockName
+		t.Run(blockName, func(t *testing.T) {
+			t.Parallel()
+
+			block := clusterFeaturesNestedAttribute(t, blockName)
+
+			wired := false
+			for _, mod := range block.PlanModifiers {
+				if _, ok := mod.(rejectExistingVpcChangeModifier); ok {
+					wired = true
+				}
+			}
+			require.True(t, wired,
+				"features.%s must carry RejectExistingVpcChange at the object level", blockName)
+
+			attrTypes := map[string]attr.Type{"id": types.StringType}
+			stateValue := types.ObjectValueMust(attrTypes, map[string]attr.Value{"id": types.StringValue("vpc-a")})
+			raw := types.StringValue("non-empty-resource")
+
+			immutableChanges := []struct {
+				changeName string
+				planValue  types.Object
+			}{
+				{"block_removal", types.ObjectNull(attrTypes)},
+				{"child_value_change", types.ObjectValueMust(attrTypes, map[string]attr.Value{"id": types.StringValue("vpc-b")})},
+			}
+			for _, change := range immutableChanges {
+				requiresReplace := false
+				hasError := false
+				for _, mod := range block.PlanModifiers {
+					resp := &planmodifier.ObjectResponse{PlanValue: change.planValue}
+					mod.PlanModifyObject(context.Background(), planmodifier.ObjectRequest{
+						State:      buildState(&raw),
+						StateValue: stateValue,
+						Plan:       buildPlan(&raw),
+						PlanValue:  change.planValue,
+					}, resp)
+					requiresReplace = requiresReplace || resp.RequiresReplace
+					hasError = hasError || resp.Diagnostics.HasError()
+				}
+				assert.False(t, requiresReplace,
+					"features.%s %s must not force cluster replacement", blockName, change.changeName)
+				assert.True(t, hasError,
+					"features.%s %s must produce a plan error", blockName, change.changeName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Reject existing VPC subnet list changes after cluster creation instead of planning an in-place update
- Add a list plan modifier that emits a clear plan error without forcing cluster replacement
- Add a schema regression test covering immutable existing VPC subnet lists

## Test Plan
- go test -tags=unit ./qovery -run TestClusterExistingVpcSubnetLists_RejectUpdates -count=1
- PATH="$HOME/go/bin:$PATH" go generate ./...
- go test -tags=unit ./... -count=1