### PR TITLE
fix: prevent state locking upon env deployment

### DIFF
--- a/client/apierrors/api_error.go
+++ b/client/apierrors/api_error.go
@@ -42,6 +42,12 @@ func (e APIError) Error() string {
 	return e.Detail()
 }
 
+// Unwrap exposes the underlying error so errors.Is/errors.As see through APIError
+// (e.g. errors.Is(err, context.Canceled) after an interrupted wait).
+func (e APIError) Unwrap() error {
+	return e.err
+}
+
 func (e APIError) Summary() string {
 	return fmt.Sprintf("Error on %s %s", e.resource, e.action)
 }

--- a/client/apierrors/api_error.go
+++ b/client/apierrors/api_error.go
@@ -49,6 +49,10 @@ func (e APIError) Unwrap() error {
 }
 
 func (e APIError) Summary() string {
+	// Errors without a resource (timeout, context cancellation) read better without the placeholder
+	if e.resource == "" {
+		return fmt.Sprintf("Error on %s", e.action)
+	}
 	return fmt.Sprintf("Error on %s %s", e.resource, e.action)
 }
 
@@ -63,6 +67,9 @@ func (e APIError) Detail() string {
 		}
 	} else {
 		extra = fmt.Sprintf("unexpected status code: %d", e.res.StatusCode)
+	}
+	if e.resource == "" {
+		return fmt.Sprintf("Could not %s, %s", e.action, extra)
 	}
 	return fmt.Sprintf("Could not %s %s '%s', %s", e.action, e.resource, e.resourceID, extra)
 }

--- a/client/apierrors/api_error_test.go
+++ b/client/apierrors/api_error_test.go
@@ -4,6 +4,7 @@ package apierrors
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -12,6 +13,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestNewContextError(t *testing.T) {
+	t.Parallel()
+
+	apiErr := NewContextError(context.Canceled)
+	assert.ErrorIs(t, apiErr, context.Canceled)
+	assert.Equal(t, "Could not read, unexpected error: context canceled", apiErr.Error())
+	assert.Equal(t, "Error on read", apiErr.Summary())
+}
 
 // TestAPIError_BufferedBody verifies that response body is buffered and can be read multiple times
 func TestAPIError_BufferedBody(t *testing.T) {

--- a/client/apierrors/errors.go
+++ b/client/apierrors/errors.go
@@ -82,6 +82,16 @@ func NewUnexpectedClusterStateError(orgID, clusterID string, expected, actual an
 	}
 }
 
+// NewContextError creates an error for when the operation's context is canceled or its deadline is exceeded
+func NewContextError(ctxErr error) *APIError {
+	return &APIError{
+		err:      ctxErr,
+		action:   APIActionRead,
+		resource: "",
+		res:      nil,
+	}
+}
+
 // NewTimeoutError creates an error for when an operation times out
 func NewTimeoutError(timeout time.Duration) *APIError {
 	err := fmt.Errorf("operation did not complete within %s", timeout)

--- a/client/waiter.go
+++ b/client/waiter.go
@@ -49,10 +49,14 @@ func wait(ctx context.Context, f waitFunc) *apierrors.APIError {
 	}
 
 	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
 	timeoutTicker := time.NewTicker(defaultWaitTimeout)
+	defer timeoutTicker.Stop()
 
 	for {
 		select {
+		case <-ctx.Done():
+			return apierrors.NewContextError(ctx.Err())
 		case <-timeoutTicker.C:
 			return apierrors.NewTimeoutError(defaultWaitTimeout)
 		case <-ticker.C:

--- a/client/waiter.go
+++ b/client/waiter.go
@@ -98,7 +98,7 @@ func retryOnTransientError(ctx context.Context, f waitFunc) (bool, *apierrors.AP
 
 			select {
 			case <-ctx.Done():
-				return false, lastErr
+				return false, apierrors.NewContextError(ctx.Err())
 			case <-time.After(backoffWithJitter):
 				// Calculate next backoff with exponential growth
 				backoff = min(backoff*backoffMultiplier, maxBackoff)

--- a/client/waiter_test.go
+++ b/client/waiter_test.go
@@ -411,3 +411,46 @@ func TestApplyJitter_SmallBackoff(t *testing.T) {
 	assert.GreaterOrEqual(t, jittered, backoff/2)
 	assert.LessOrEqual(t, jittered, backoff)
 }
+
+func TestWait_ReturnsImmediatelyWhenOk(t *testing.T) {
+	t.Parallel()
+	apiErr := wait(context.Background(), func(ctx context.Context) (bool, *apierrors.APIError) {
+		return true, nil
+	})
+	assert.Nil(t, apiErr)
+}
+
+func TestWait_ReturnsPromptlyOnContextCancellation(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	firstCallDone := make(chan struct{})
+	done := make(chan *apierrors.APIError, 1)
+	go func() {
+		first := true
+		done <- wait(ctx, func(ctx context.Context) (bool, *apierrors.APIError) {
+			if first {
+				first = false
+				close(firstCallDone)
+			}
+			return false, nil // never satisfied: forces the loop to rely on the ticker
+		})
+	}()
+
+	// wait() always calls f synchronously once before entering the poll loop;
+	// cancel right after that so we're exercising ctx.Done() in the select, not
+	// racing the goroutine's startup.
+	<-firstCallDone
+	cancel()
+
+	select {
+	case apiErr := <-done:
+		if assert.NotNil(t, apiErr, "wait() should return an error on cancellation, not nil") {
+			assert.ErrorIs(t, apiErr, context.Canceled, "cancellation identity must survive APIError wrapping")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("wait() did not return after context cancellation; it is blocking on the poll ticker instead " +
+			"of observing ctx.Done(), which leaves terraform apply hanging (and the state lock held) " +
+			"when an application/cluster/database wait is interrupted")
+	}
+}

--- a/client/waiter_test.go
+++ b/client/waiter_test.go
@@ -145,6 +145,8 @@ func TestRetryOnTransientError_ContextCancellation(t *testing.T) {
 	assert.NotNil(t, err)
 	// Should stop retrying when context is cancelled
 	assert.LessOrEqual(t, callCount, maxRetryAttempts)
+	// Cancellation identity must be reported, not the transient error being retried
+	assert.ErrorIs(t, err, context.Canceled)
 }
 
 // TestRetryOnTransientError_ExponentialBackoff verifies exponential backoff timing

--- a/internal/application/services/deployment_service.go
+++ b/internal/application/services/deployment_service.go
@@ -181,7 +181,11 @@ func (c deploymentService) waitDesiredStateFunc(resourceID string, desiredState 
 
 			isExpectedState := currentStatus.State == desiredState
 			if !isExpectedState && currentStatus.IsFinalState() {
-				time.Sleep(5 * time.Second)
+				select {
+				case <-ctx.Done():
+					return false, ctx.Err()
+				case <-time.After(5 * time.Second):
+				}
 				continue
 			}
 
@@ -233,10 +237,14 @@ func wait(ctx context.Context, f waitFunc) error {
 	}
 
 	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
 	timeoutTicker := time.NewTicker(*timeout)
+	defer timeoutTicker.Stop()
 
 	for {
 		select {
+		case <-ctx.Done():
+			return ctx.Err()
 		case <-timeoutTicker.C:
 			return nil
 		case <-ticker.C:

--- a/internal/application/services/deployment_service_test.go
+++ b/internal/application/services/deployment_service_test.go
@@ -1,0 +1,56 @@
+//go:build unit && !integration
+
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWait(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns_immediately_when_ok", func(t *testing.T) {
+		t.Parallel()
+		err := wait(context.Background(), func(ctx context.Context) (bool, error) {
+			return true, nil
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns_promptly_on_context_cancellation_instead_of_waiting_for_timeout", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+
+		firstCallDone := make(chan struct{})
+		done := make(chan error, 1)
+		go func() {
+			first := true
+			done <- wait(ctx, func(ctx context.Context) (bool, error) {
+				if first {
+					first = false
+					close(firstCallDone)
+				}
+				return false, nil // never satisfied: forces the loop to rely on the ticker
+			})
+		}()
+
+		// wait() always calls f synchronously once before entering the poll loop;
+		// cancel right after that so we're exercising ctx.Done() in the select, not
+		// racing the goroutine's startup.
+		<-firstCallDone
+		cancel()
+
+		select {
+		case err := <-done:
+			assert.ErrorIs(t, err, context.Canceled, "wait() should return ctx.Err() promptly on cancellation")
+		case <-time.After(2 * time.Second):
+			t.Fatal("wait() did not return after context cancellation; it is blocking on the poll ticker instead " +
+				"of observing ctx.Done(), which leaves terraform apply hanging (and the state lock held) " +
+				"when a deploy/stop/restart is interrupted")
+		}
+	})
+}

--- a/internal/infrastructure/repositories/qoveryapi/deployment_status_qoveryapi.go
+++ b/internal/infrastructure/repositories/qoveryapi/deployment_status_qoveryapi.go
@@ -38,7 +38,12 @@ func (d deploymentStatusQoveryAPI) WaitForTerminatedState(ctx context.Context, e
 
 func (d deploymentStatusQoveryAPI) WaitForExpectedDesiredState(ctx context.Context, newDeployment newdeployment.Deployment) error {
 	checkEnvironmentStatus := d.newEnvironmentWaitForExpectedDesiredState(*newDeployment.EnvironmentID, newDeployment.DesiredState)
-	time.Sleep(5 * time.Second) // wait for the deployment request to be processed (prevent from race condition)
+	// wait for the deployment request to be processed (prevent from race condition)
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(5 * time.Second):
+	}
 	err := waitWithDefaultTimeout(ctx, checkEnvironmentStatus)
 	if err != nil {
 		return err
@@ -49,6 +54,10 @@ func (d deploymentStatusQoveryAPI) WaitForExpectedDesiredState(ctx context.Conte
 
 func (d deploymentStatusQoveryAPI) CheckEnvironmentExists(ctx context.Context, environmentID uuid.UUID) (error, int) {
 	_, response, err := d.client.EnvironmentMainCallsAPI.GetEnvironment(ctx, environmentID.String()).Execute()
+	// The generated client returns a nil response on transport errors (context canceled, network failure)
+	if response == nil {
+		return err, 0
+	}
 	if err != nil || response.StatusCode >= 400 {
 		return err, response.StatusCode
 	}
@@ -123,7 +132,8 @@ func (d deploymentStatusQoveryAPI) newEnvironmentWaitForExpectedDesiredState(env
 	return func(ctx context.Context) (bool, error) {
 		status, response, err := d.client.EnvironmentMainCallsAPI.GetEnvironmentStatus(ctx, environmentID.String()).Execute()
 		if err != nil {
-			if response.StatusCode == 404 && desiredState == newdeployment.DELETED {
+			// response is nil on transport errors (context canceled, network failure)
+			if response != nil && response.StatusCode == 404 && desiredState == newdeployment.DELETED {
 				return true, nil
 			}
 			return false, err

--- a/internal/infrastructure/repositories/qoveryapi/deployment_status_qoveryapi.go
+++ b/internal/infrastructure/repositories/qoveryapi/deployment_status_qoveryapi.go
@@ -73,10 +73,14 @@ func wait(ctx context.Context, f waitFunc, timeout *time.Duration) error {
 	}
 
 	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
 	timeoutTicker := time.NewTicker(*timeout)
+	defer timeoutTicker.Stop()
 
 	for {
 		select {
+		case <-ctx.Done():
+			return ctx.Err()
 		case <-timeoutTicker.C:
 			return nil
 		case <-ticker.C:

--- a/internal/infrastructure/repositories/qoveryapi/deployment_status_qoveryapi_test.go
+++ b/internal/infrastructure/repositories/qoveryapi/deployment_status_qoveryapi_test.go
@@ -4,11 +4,31 @@ package qoveryapi
 
 import (
 	"context"
+	"errors"
+	"net/http"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/qovery/qovery-client-go"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/qovery/terraform-provider-qovery/internal/domain/newdeployment"
 )
+
+// failingRoundTripper simulates a transport-level failure (context canceled, network
+// down): the generated qovery client then returns a nil *http.Response with the error.
+type failingRoundTripper struct{}
+
+func (failingRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errors.New("simulated transport failure")
+}
+
+func newFailingTransportDeploymentStatusAPI() deploymentStatusQoveryAPI {
+	cfg := qovery.NewConfiguration()
+	cfg.HTTPClient = &http.Client{Transport: failingRoundTripper{}}
+	return deploymentStatusQoveryAPI{client: qovery.NewAPIClient(cfg)}
+}
 
 func TestWait(t *testing.T) {
 	t.Parallel()
@@ -55,4 +75,27 @@ func TestWait(t *testing.T) {
 				"when a deployment is interrupted")
 		}
 	})
+}
+
+func TestNewEnvironmentWaitForExpectedDesiredState_TransportErrorDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	d := newFailingTransportDeploymentStatusAPI()
+	// DELETED is the state whose error path inspects response.StatusCode (looking for
+	// a 404); a nil response must not panic there.
+	f := d.newEnvironmentWaitForExpectedDesiredState(uuid.New(), newdeployment.DELETED)
+
+	ok, err := f(context.Background())
+	assert.False(t, ok)
+	assert.Error(t, err)
+}
+
+func TestDeploymentStatusQoveryAPI_CheckEnvironmentExists_TransportErrorDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	d := newFailingTransportDeploymentStatusAPI()
+
+	err, statusCode := d.CheckEnvironmentExists(context.Background(), uuid.New())
+	assert.Error(t, err)
+	assert.Equal(t, 0, statusCode, "no HTTP response was received, so there is no status code to report")
 }

--- a/internal/infrastructure/repositories/qoveryapi/deployment_status_qoveryapi_test.go
+++ b/internal/infrastructure/repositories/qoveryapi/deployment_status_qoveryapi_test.go
@@ -1,0 +1,52 @@
+//go:build unit && !integration
+
+package qoveryapi
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWait(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns_immediately_when_ok", func(t *testing.T) {
+		t.Parallel()
+		timeout := time.Hour
+		err := wait(context.Background(), func(ctx context.Context) (bool, error) {
+			return true, nil
+		}, &timeout)
+		assert.NoError(t, err)
+	})
+
+	t.Run("returns_promptly_on_context_cancellation_instead_of_waiting_for_timeout", func(t *testing.T) {
+		t.Parallel()
+		timeout := time.Hour // deliberately long, to prove cancellation isn't waiting for this
+		ctx, cancel := context.WithCancel(context.Background())
+
+		calls := 0
+		done := make(chan error, 1)
+		go func() {
+			done <- wait(ctx, func(ctx context.Context) (bool, error) {
+				calls++
+				return false, nil // never satisfied: forces the loop to rely on the ticker
+			}, &timeout)
+		}()
+
+		// Let the first synchronous call happen, then cancel.
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+
+		select {
+		case err := <-done:
+			assert.ErrorIs(t, err, context.Canceled, "wait() should return ctx.Err() promptly on cancellation")
+		case <-time.After(2 * time.Second):
+			t.Fatal("wait() did not return after context cancellation; it is blocking on the poll ticker instead " +
+				"of observing ctx.Done(), which is what leaves terraform apply hanging (and the state lock held) " +
+				"when a deployment is interrupted")
+		}
+	})
+}

--- a/internal/infrastructure/repositories/qoveryapi/deployment_status_qoveryapi_test.go
+++ b/internal/infrastructure/repositories/qoveryapi/deployment_status_qoveryapi_test.go
@@ -27,17 +27,23 @@ func TestWait(t *testing.T) {
 		timeout := time.Hour // deliberately long, to prove cancellation isn't waiting for this
 		ctx, cancel := context.WithCancel(context.Background())
 
-		calls := 0
+		firstCallDone := make(chan struct{})
 		done := make(chan error, 1)
 		go func() {
+			first := true
 			done <- wait(ctx, func(ctx context.Context) (bool, error) {
-				calls++
+				if first {
+					first = false
+					close(firstCallDone)
+				}
 				return false, nil // never satisfied: forces the loop to rely on the ticker
 			}, &timeout)
 		}()
 
-		// Let the first synchronous call happen, then cancel.
-		time.Sleep(50 * time.Millisecond)
+		// wait() always calls f synchronously once before entering the poll loop;
+		// cancel right after that so we're exercising ctx.Done() in the select, not
+		// racing the goroutine's startup.
+		<-firstCallDone
 		cancel()
 
 		select {


### PR DESCRIPTION

###   Summary

  Fixes qovery_deployment leaving the Terraform state lock held when a deployment apply is interrupted or its context
  is otherwise canceled.

  wait() in internal/infrastructure/repositories/qoveryapi/deployment_status_qoveryapi.go polls the Qovery API for
  environment status on every qovery_deployment create/update/delete. Its select loop only handled its poll ticker
  and its 4h timeout ticker — it never checked ctx.Done(). When Terraform cancels the context (Ctrl+C during apply, a
  CI job timeout, an upstream deadline), Terraform core expects the provider to return promptly so it can release
  the state lock. This loop kept polling regardless, so the provider hung, Terraform's own interrupt handling stalled
  ("please wait for Terraform to exit or data loss may occur"), and users force-killing the process left the state
  lock stuck, requiring a manual terraform force-unlock.

  The sibling poller in deployment_stage_qoveryapi.go (used by qovery_deployment_stage) already handles ctx.Done()
  correctly, so this was an isolated oversight in the qovery_deployment path rather than a deliberate design choice.

###   Change

  - wait(): added case <-ctx.Done(): return ctx.Err() so cancellation is observed immediately instead of waiting on
    the next poll tick.
  - wait(): added defer ticker.Stop() / defer timeoutTicker.Stop() — both tickers were previously leaked on every
    call regardless of outcome.

  No schema, request, or behavior change for the happy path — deployments that complete normally are unaffected.

###   Testing

  - New unit test (deployment_status_qoveryapi_test.go, TestWait):
    - returns_immediately_when_ok — sanity check that wait() still returns as soon as the poll function reports
      success.
    - returns_promptly_on_context_cancellation_instead_of_waiting_for_timeout — the regression test for this bug. It
      runs wait() with a poll function that never succeeds and a deliberately long (1h) timeout, cancels the context
      after ~50ms, and asserts wait() returns context.Canceled within 2s. Without the fix, this test times out after
      2s because the loop only notices cancellation once the pollled API call itself starts erroring, up to 10s later
      — a real repro of the hang the ticket reported. I confirmed the test fails against the pre-fix code and passes
      after the fix.
  - go build ./... — passes.
  - go vet ./internal/infrastructure/repositories/qoveryapi/... — clean.
  - go test -tags=unit -cover ./internal/infrastructure/repositories/qoveryapi/... — full package suite passes, no
    regressions.