### PR TITLE
chore: schedule provider tests at 09:00 and 16:00 CET

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,8 +12,8 @@ on:
       - "README.md"
       - ".gitignore"
   schedule:
-    - cron: "0 9 * * 1-5"  # 09:00 UTC, Mon-Fri
-    - cron: "0 16 * * 1-5" # 16:00 UTC, Mon-Fri (18:00 Paris)
+    - cron: "0 8 * * 1-5"  # 08:00 UTC, Mon-Fri (09:00 CET)
+    - cron: "0 15 * * 1-5" # 15:00 UTC, Mon-Fri (16:00 CET)
 
 permissions:
   contents: read
@@ -220,7 +220,7 @@ jobs:
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Trigger:*\nScheduled (${{ github.event.schedule == '0 9 * * 1-5' && '09:00 UTC, morning' || '16:00 UTC, end of day' }})"
+                      "text": "*Trigger:*\nScheduled (${{ github.event.schedule == '0 8 * * 1-5' && '09:00 CET, morning' || '16:00 CET, end of day' }})"
                     }
                   ]
                 },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adjusts the scheduled provider tests to run at 09:00 and 16:00 CET instead of UTC, so they trigger at the intended local time. Also updates the Slack notification labels accordingly.

<sup>Written for commit 47108c0805065ecf9df3abf3787592406aa1bedb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/terraform-provider-qovery/pull/619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

