### PR TITLE
fix(terraformservice): identify the offending variable in validation errors

### DIFF
--- a/internal/domain/terraformservice/terraformservice.go
+++ b/internal/domain/terraformservice/terraformservice.go
@@ -200,8 +200,23 @@ func (v Variable) Validate() error {
 		return errors.New("variable key is required")
 	}
 	if v.Value == "" {
-		return errors.New("variable value is required")
+		return fmt.Errorf("variable %q: value is required", v.Key)
 	}
+	return nil
+}
+
+// validateVariables validates every variable, identifying the offending one in the error.
+// The index is a fallback for the one case Variable.Validate cannot name: an empty key.
+func validateVariables(variables []Variable) error {
+	for i, v := range variables {
+		if err := v.Validate(); err != nil {
+			if v.Key == "" {
+				return errors.Wrapf(err, "variable at index %d", i)
+			}
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -334,17 +349,15 @@ func (t TerraformService) Validate() error {
 		// Check for directory traversal
 		if strings.Contains(tfVarPath, "..") || strings.Contains(tfVarPath, "~") {
 			return errors.Wrap(
-				errors.New("tfvar path cannot contain directory traversal sequences (.., ~)"),
+				fmt.Errorf("tfvar path %q cannot contain directory traversal sequences (.., ~)", tfVarPath),
 				ErrInvalidTerraformServiceTfVarPathParam.Error(),
 			)
 		}
 	}
 
 	// Validate variables
-	for _, variable := range t.Variables {
-		if err := variable.Validate(); err != nil {
-			return errors.Wrap(err, ErrInvalidTerraformServiceVariableParam.Error())
-		}
+	if err := validateVariables(t.Variables); err != nil {
+		return errors.Wrap(err, ErrInvalidTerraformServiceVariableParam.Error())
 	}
 
 	// Validate backend

--- a/internal/domain/terraformservice/terraformservice_repository.go
+++ b/internal/domain/terraformservice/terraformservice_repository.go
@@ -81,10 +81,8 @@ func (r UpsertRepositoryRequest) Validate() error {
 	}
 
 	// Validate variables
-	for _, variable := range r.Variables {
-		if err := variable.Validate(); err != nil {
-			return errors.Wrap(err, ErrInvalidTerraformServiceUpsertRequest.Error())
-		}
+	if err := validateVariables(r.Variables); err != nil {
+		return errors.Wrap(err, ErrInvalidTerraformServiceUpsertRequest.Error())
 	}
 
 	// Validate timeout

--- a/internal/domain/terraformservice/terraformservice_test.go
+++ b/internal/domain/terraformservice/terraformservice_test.go
@@ -556,3 +556,201 @@ func TestUpsertRepositoryRequest_Validate(t *testing.T) {
 func stringPtr(s string) *string {
 	return &s
 }
+
+func TestVariable_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		variable    terraformservice.Variable
+		expectedErr string
+	}{
+		{
+			name:     "valid variable",
+			variable: terraformservice.Variable{Key: "record_name", Value: "example.com"},
+		},
+		{
+			name:        "missing key",
+			variable:    terraformservice.Variable{Key: "", Value: "example.com"},
+			expectedErr: "variable key is required",
+		},
+		{
+			name:        "missing value names the offending key",
+			variable:    terraformservice.Variable{Key: "record_name", Value: ""},
+			expectedErr: `variable "record_name": value is required`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.variable.Validate()
+			if tt.expectedErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.EqualError(t, err, tt.expectedErr)
+		})
+	}
+}
+
+func TestTerraformService_Validate_VariableErrorsIdentifyTheVariable(t *testing.T) {
+	t.Parallel()
+
+	newService := func(variables []terraformservice.Variable) terraformservice.TerraformService {
+		return terraformservice.TerraformService{
+			ID:            uuid.New(),
+			EnvironmentID: uuid.New(),
+			Name:          "test-service",
+			GitRepository: terraformservice.GitRepository{
+				URL:      "https://github.com/org/repo",
+				Branch:   "main",
+				RootPath: "/",
+			},
+			Variables:     variables,
+			Backend:       terraformservice.Backend{Kubernetes: &terraformservice.KubernetesBackend{}},
+			Engine:        terraformservice.EngineTerraform,
+			EngineVersion: terraformservice.EngineVersion{ExplicitVersion: "1.5.7"},
+			JobResources: terraformservice.JobResources{
+				CPUMilli:   1000,
+				RAMMiB:     1024,
+				GPU:        0,
+				StorageGiB: 20,
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		variables   []terraformservice.Variable
+		expectedErr string
+	}{
+		{
+			name: "empty value reports the key, not just the position",
+			variables: []terraformservice.Variable{
+				{Key: "domain", Value: "example.com"},
+				{Key: "record_name", Value: ""},
+			},
+			expectedErr: `invalid variable param: variable "record_name": value is required`,
+		},
+		{
+			name: "empty key falls back to the index",
+			variables: []terraformservice.Variable{
+				{Key: "domain", Value: "example.com"},
+				{Key: "", Value: "some-value"},
+			},
+			expectedErr: "invalid variable param: variable at index 1: variable key is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.EqualError(t, newService(tt.variables).Validate(), tt.expectedErr)
+		})
+	}
+}
+
+func TestUpsertRepositoryRequest_Validate_VariableErrorsIdentifyTheVariable(t *testing.T) {
+	t.Parallel()
+
+	newRequest := func(variables []terraformservice.Variable) terraformservice.UpsertRepositoryRequest {
+		return terraformservice.UpsertRepositoryRequest{
+			Name: "test-service",
+			GitRepository: terraformservice.GitRepository{
+				URL:      "https://github.com/org/repo",
+				Branch:   "main",
+				RootPath: "/",
+			},
+			Variables:     variables,
+			Backend:       terraformservice.Backend{Kubernetes: &terraformservice.KubernetesBackend{}},
+			Engine:        terraformservice.EngineTerraform,
+			EngineVersion: terraformservice.EngineVersion{ExplicitVersion: "1.5.7"},
+			JobResources: terraformservice.JobResources{
+				CPUMilli:   1000,
+				RAMMiB:     1024,
+				GPU:        0,
+				StorageGiB: 20,
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		variables   []terraformservice.Variable
+		expectedErr string
+	}{
+		{
+			name: "empty value reports the key",
+			variables: []terraformservice.Variable{
+				{Key: "domain", Value: "example.com"},
+				{Key: "record_name", Value: ""},
+			},
+			expectedErr: `invalid terraform service upsert request: variable "record_name": value is required`,
+		},
+		{
+			name: "empty key falls back to the index",
+			variables: []terraformservice.Variable{
+				{Key: "", Value: "some-value"},
+			},
+			expectedErr: "invalid terraform service upsert request: variable at index 0: variable key is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.EqualError(t, newRequest(tt.variables).Validate(), tt.expectedErr)
+		})
+	}
+}
+
+func TestTerraformService_Validate_TfVarPathErrorsIdentifyThePath(t *testing.T) {
+	t.Parallel()
+
+	newService := func(rootPath string, tfVarFiles []string) terraformservice.TerraformService {
+		return terraformservice.TerraformService{
+			ID:            uuid.New(),
+			EnvironmentID: uuid.New(),
+			Name:          "test-service",
+			GitRepository: terraformservice.GitRepository{
+				URL:      "https://github.com/org/repo",
+				Branch:   "main",
+				RootPath: rootPath,
+			},
+			TfVarFiles:    tfVarFiles,
+			Backend:       terraformservice.Backend{Kubernetes: &terraformservice.KubernetesBackend{}},
+			Engine:        terraformservice.EngineTerraform,
+			EngineVersion: terraformservice.EngineVersion{ExplicitVersion: "1.5.7"},
+			JobResources: terraformservice.JobResources{
+				CPUMilli:   1000,
+				RAMMiB:     1024,
+				GPU:        0,
+				StorageGiB: 20,
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		rootPath    string
+		tfVarFiles  []string
+		expectedErr string
+	}{
+		{
+			name:        "path outside root_path",
+			rootPath:    "/terraform",
+			tfVarFiles:  []string{"/terraform/prod.tfvars", "/invalid/prod.tfvars"},
+			expectedErr: `invalid tfvar path: must start with root_path: tfvar path "/invalid/prod.tfvars" must start with root_path "/terraform"`,
+		},
+		{
+			name:        "directory traversal reports the offending path",
+			rootPath:    "/",
+			tfVarFiles:  []string{"/prod.tfvars", "/../secrets.tfvars"},
+			expectedErr: `invalid tfvar path: must start with root_path: tfvar path "/../secrets.tfvars" cannot contain directory traversal sequences (.., ~)`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.EqualError(t, newService(tt.rootPath, tt.tfVarFiles).Validate(), tt.expectedErr)
+		})
+	}
+}


### PR DESCRIPTION
#### What

Variable validation errors now name the variable:

```
invalid variable param: variable "record_name": value is required
```

A variable with an empty key has no name to report, so those fall back to its
position: `variable at index 3: variable key is required`.

The same fix applies to the tfvar-path directory-traversal check, which was the
one path check that did not quote the offending path while its sibling
(`must start with root_path`) did.

#### Why

A `qovery_terraform_service` with a variable whose value is empty fails to apply
with `invalid variable param: variable value is required` — no key, no position.
With tens of variables the operator has to bisect the manifest by hand to find
the one at fault. This happened for real on Qovery blueprints, which render a
`qovery_terraform_service` from a catalog manifest and pass every variable
through this validation (QOV-2213); it cost a day of bisection across 9
blueprints.


#### Notes

Validation *behaviour* is unchanged — same inputs accepted, same inputs
rejected. Only message text moved.

`UpsertRepositoryRequest.Validate` and `TerraformService.Validate` had the same
loop duplicated; both now call one `validateVariables` helper and keep their own
outer sentinel error, so `errors.Is` behaviour on those sentinels is untouched.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validation errors for `qovery_terraform_service` variables now name the offending variable or its index, so operators no longer have to bisect large manifests to find the bad entry. The tfvar-path directory-traversal error now quotes the offending path too. Validation behavior is unchanged; only message text moved.

- Empty variable values report the key, e.g. `variable "record_name": value is required`; empty keys fall back to `variable at index 3: variable key is required`.
- The duplicated variable-validation loop in `UpsertRepositoryRequest.Validate` and `TerraformService.Validate` now shares one `validateVariables` helper; sentinel error wrapping stays intact.

<sup>Written for commit 37265b329c5b8fc46aa094bc77d1639efc57df37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/terraform-provider-qovery/pull/620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

