### PR TITLE
chore: schedule provider tests at 07:38 and 14:38 UTC

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,8 +12,10 @@ on:
       - "README.md"
       - ".gitignore"
   schedule:
-    - cron: "0 8 * * 1-5"  # 08:00 UTC, Mon-Fri (09:00 CET)
-    - cron: "0 15 * * 1-5" # 15:00 UTC, Mon-Fri (16:00 CET)
+    # GitHub cron is UTC only and runs queued at :00 are the most delayed
+    # (peak load), so both crons sit at :38. Paris is UTC+2 in summer, UTC+1 in winter.
+    - cron: "38 7 * * 1-5"  # 07:38 UTC, Mon-Fri (09:38 Paris in summer, 08:38 in winter)
+    - cron: "38 14 * * 1-5" # 14:38 UTC, Mon-Fri (16:38 Paris in summer, 15:38 in winter)
 
 permissions:
   contents: read
@@ -220,7 +222,7 @@ jobs:
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Trigger:*\nScheduled (${{ github.event.schedule == '0 8 * * 1-5' && '09:00 CET, morning' || '16:00 CET, end of day' }})"
+                      "text": "*Trigger:*\nScheduled (${{ github.event.schedule == '38 7 * * 1-5' && 'morning run, 07:38 UTC' || 'afternoon run, 14:38 UTC' }})"
                     }
                   ]
                 },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moves the scheduled provider test runs from 08:00 and 15:00 UTC to 07:38 and 14:38 UTC so they avoid GitHub's peak load at the top of the hour. The Slack notification text now shows the new UTC trigger times instead of CET times.

<sup>Written for commit 15dcd86e651359723dcd00afc194dae5ed6a5305. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/terraform-provider-qovery/pull/621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

